### PR TITLE
Persist scraped attractions from Tripadvisor in JSON file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,8 +49,7 @@ puts "Creating attractions..."
 
 Rake::Task['gov_attractions:update'].invoke
 Rake::Task['gov_attractions:clean'].invoke
-# CAUTION: The following makes ~300 API requests to TripAdvisor API
-# Rake::Task['gov_attractions:merge'].invoke
+Rake::Task['gov_attractions:merge'].invoke
 
 puts "Creating itineraries Attractions..."
 

--- a/lib/tasks/trip_advisor_data.json
+++ b/lib/tasks/trip_advisor_data.json
@@ -1,0 +1,22841 @@
+{
+  "National Gallery Singapore": [
+    {
+      "location_id": "8077179",
+      "name": "National Gallery Singapore",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/ec/5b/45/national-gallery-singapore.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0a/38/fb/c9/national-gallery-singapore.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/24/74/e8/36/at-the-gallery.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/24/74/e8/35/padang-atrium.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/24/74/e8/2c/holding-cells.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "That's confusing!",
+          "text": "The banner hung on the outside of the building definitely says 'Free Entry' (see photo), but when we went in, we were asked for $15 each. Didn't stay, as we didn't have enough time to do the charge justice"
+        },
+        {
+          "title": "Majulah",
+          "text": "wonderful place... \nseriously i love singapore , located 1km from merlion park finding remakable art cannot describe 😍"
+        },
+        {
+          "title": "A brilliant space perfect for exploration and discovery",
+          "text": "I was truly in my happy place exploring the many galleries in the National Art Gallery. \n\nThis is truly an incredible building architecturally speaking and it houses an equally impressive modern visual art collection. The finest in South East Asia. There are other galleries here too devoted to the history of art in Singapore & the region, exploring the deep connections between the changes in Singapore and their impact on wider culture and the art scene. I learned so much this morning as this is only my second visit to Singapore and my first with my partner.\n\nThis is where today’s visit was so special. I love art and have done so for many decades, simply put, my partner is not as interested in it as I am. Yet this visit triggered something. What I thought would only be a 1-2 hours at most visit before my partner became restless turned into a half day visit where quite often we wondered off in different directions exploring on our own only for me to discover my partner intently viewing modern works & sculptures and taking lots and lots of photos of the architecture of the amazing building too. \n\nWhen I asked what was different, the response was simply it did not feel like a normal art gallery and the layout and architecture all combined to create an inviting space for exploration & discovery. I hope this is the start of something new for us. Thank you National Gallery Singapore!"
+        },
+        {
+          "title": "A Captivating Journey Through Art and History",
+          "text": "The National Gallery Singapore is a must-visit for art and culture enthusiasts. The beautifully restored buildings house an incredible collection of Southeast Asian and Singaporean art, offering a perfect blend of history and creativity. The exhibits are thoughtfully curated, and the architecture itself is stunning. It’s a place where you can immerse yourself in art while enjoying breathtaking views of the city. Highly recommended!"
+        },
+        {
+          "title": "We've been to art museums all over the world - and this is up there with the best of them",
+          "text": "This sprawling complex offers so much to see that we found several hours had passed almost without us noticing. Staff are incredibly friendly and helpful, there are great places to eat and drink, a nice shop, and amazing architecture. Plus, the art is just so good and so varied, and offers a real insight into Singapore and SE Asia. Highly recommended."
+        }
+      ],
+      "description": "National Gallery Singapore is a leading visual arts institution in Southeast Asia which oversees the world’s largest public collection of modern art in Singapore and the region. Situated in the heart of the Civic District, the National Gallery Singapore has been beautifully restored and transformed from the former Supreme Court and City Hall buildings into an exciting new visual arts venue.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d8077179-Reviews-National_Gallery_Singapore-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 St. Andrew_s Road",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "178957",
+        "address_string": "1 St. Andrew_s Road, Singapore 178957 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.290224",
+      "longitude": "103.85152",
+      "timezone": "Asia/Singapore",
+      "email": "info@nationalgallery.sg",
+      "phone": "+65 6271 7000",
+      "website": "http://www.nationalgallery.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d8077179-National_Gallery_Singapore-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#41 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "41"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "1345",
+      "review_rating_count": {
+        "1": "17",
+        "2": "39",
+        "3": "114",
+        "4": "388",
+        "5": "787"
+      },
+      "photo_count": "2527",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d8077179-m66827-Reviews-National_Gallery_Singapore-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 19:00",
+          "Tuesday: 10:00 - 19:00",
+          "Wednesday: 10:00 - 19:00",
+          "Thursday: 10:00 - 19:00",
+          "Friday: 10:00 - 19:00",
+          "Saturday: 10:00 - 19:00",
+          "Sunday: 10:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Architectural Buildings",
+              "localized_name": "Architectural Buildings"
+            }
+          ]
+        },
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Art Museums",
+              "localized_name": "Art Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622412",
+          "name": "City Hall"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "50"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "396"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "252"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "249"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "216"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "1 St. Andrew_s Road",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "178957",
+        "address_string": "1 St. Andrew_s Road, Singapore 178957 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Sultan Mosque (Masjid Sultan) Singapore": [
+    {
+      "location_id": "317468",
+      "name": "Sultan Mosque",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/d7/9b/12/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/18/6b/cf/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/18/6b/ce/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/22/cb/58/singapore.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/67/ec/ba/sultan-mosque.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Impressive from the outside",
+          "text": "I wanted to attend the mosque as a non religious person, hoping to gain an understanding of this faith.\nSadly, I gained no real knowledge, the ‘Opening’ for the public is just of a tiny section of the pray hall with very little information about the faith.\nThe outside, was impressive, just don’t bother waiting for the open hours."
+        },
+        {
+          "title": "Muslim Mosque on 3 Muscrat Street Singapore",
+          "text": "The Sultan Mosque (Masjid Sultan) was built  in the early 1800's. It was built with donations from the rich and the poor. It is a working mosque"
+        },
+        {
+          "title": "Pleasant visit",
+          "text": "During my initial visit to a mosque, I was struck by the tourist-friendly atmosphere and the remarkable intricacy of the interior design. The aesthetic appeal of the design was truly impressive. Overall, it was a delightful tour and an enriching experience."
+        },
+        {
+          "title": "Beautiful imposing mosque",
+          "text": "Central point of the area over looking an attractive street of Middle Eastern restaurants. Pristine and bright with whites and gold. Lovely area away from busting city"
+        },
+        {
+          "title": "THE ICON OF HAJI LANE",
+          "text": "Absolutely beautiful and iconic building in Haji Lane. I didn't get to go inside as it was closed for prayer service the day I was there but it was just as amazing gazing at this beautiful building from the outside."
+        }
+      ],
+      "description": "A century later in 1928, Denis Santry, an architect of Swan and McLaren, employed the Islamic-Saracenic style that combines ideas from Indian and Islamic traditions, designing a Mosque that incorporated the use of minarets and balusters.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d317468-Reviews-Sultan_Mosque-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "3 Muscat Street",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "198833",
+        "address_string": "3 Muscat Street, Singapore 198833 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.30224",
+      "longitude": "103.85898",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6293 4405",
+      "website": "http://sultanmosque.sg/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d317468-Sultan_Mosque-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#53 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "53"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "1095",
+      "review_rating_count": {
+        "1": "5",
+        "2": "7",
+        "3": "164",
+        "4": "501",
+        "5": "418"
+      },
+      "photo_count": "1615",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d317468-m66827-Reviews-Sultan_Mosque-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0930"
+            },
+            "close": {
+              "day": 1,
+              "time": "1200"
+            }
+          },
+          {
+            "open": {
+              "day": 1,
+              "time": "1400"
+            },
+            "close": {
+              "day": 1,
+              "time": "1600"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0930"
+            },
+            "close": {
+              "day": 2,
+              "time": "1200"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1400"
+            },
+            "close": {
+              "day": 2,
+              "time": "1600"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0930"
+            },
+            "close": {
+              "day": 3,
+              "time": "1200"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1400"
+            },
+            "close": {
+              "day": 3,
+              "time": "1600"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0930"
+            },
+            "close": {
+              "day": 4,
+              "time": "1200"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1400"
+            },
+            "close": {
+              "day": 4,
+              "time": "1600"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1430"
+            },
+            "close": {
+              "day": 5,
+              "time": "1600"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0930"
+            },
+            "close": {
+              "day": 6,
+              "time": "1200"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1400"
+            },
+            "close": {
+              "day": 6,
+              "time": "1600"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0930"
+            },
+            "close": {
+              "day": 7,
+              "time": "1200"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1400"
+            },
+            "close": {
+              "day": 7,
+              "time": "1600"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 09:30 - 12:00,  14:00 - 16:00",
+          "Tuesday: 09:30 - 12:00,  14:00 - 16:00",
+          "Wednesday: 09:30 - 12:00,  14:00 - 16:00",
+          "Thursday: 09:30 - 12:00,  14:00 - 16:00",
+          "Friday: 14:30 - 16:00",
+          "Saturday: 09:30 - 12:00,  14:00 - 16:00",
+          "Sunday: 09:30 - 12:00,  14:00 - 16:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            },
+            {
+              "name": "Sacred & Religious Sites",
+              "localized_name": "Sacred & Religious Sites"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291617",
+          "name": "Kampong Glam"
+        },
+        {
+          "location_id": "15622680",
+          "name": "Arab Street"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "22"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "271"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "199"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "198"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "198"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "3 Muscat Street",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "198833",
+        "address_string": "3 Muscat Street, Singapore 198833 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Sri Mariamman Temple: Hindu Temple in Singapore": [
+    {
+      "location_id": "324753",
+      "name": "Sri Mariamman Temple",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/77/3f/ea/photo3jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/37/0c/9d/a-hindu-temple.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/3c/0a/36/the-temple-frontage.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1a/da/2a/90/temple-devotees-at-dusk.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/18/ba/12/e7/sri-mariamman-temple.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Singapore’s oldest Hindu temple",
+          "text": "This temple in the heart of Chinatown is Singapore’s oldest temple for the Hindu faith. It is adorned with deity’s in vibrant colours. We did not spend much time there today as there was a wedding taking place.\n\nIt is worth visiting even just to admire the statues of the deities. It is very special."
+        },
+        {
+          "title": "Not iconic but worth a visit",
+          "text": "This was my second visit to the Sri Mariamman Temple in about five years. My first one was in a rain storm and I was hoping to have a but more freedom to see things this time. However, there was a lot of renovation work going on so I'm not sure I got to see this old Hindu temple in any better light. \n\nIf you happen to be near Chinatown, then it is worth a visit but not a long one, as there is not a huge amount to see. The figures and statues are very colourful, as were the ceiling paintings. Hopefully the renovations are now complete."
+        },
+        {
+          "title": "Only drop by  if you're in the area",
+          "text": "A bit underwhelming to be honest. If you are in the area anyway (as it is in Chinatown near other better attractions like the buddhist tooth relic temple) then perhaps worth popping your head in. But it only takes 5-10 mins and there isn't a whole lot to see. The buddhist temple is much better and you can spend up to an hour there."
+        },
+        {
+          "title": "Interesting temple if you’re in Chinatown",
+          "text": "Worth popping in for a look around as the temple is beautiful and the colours stunning. You have to remove your shoes as it is a place of worship so be respectful and keep to the areas where tourists are allowed. \n\nAllow about 15 minutes or so to walk around and take a few photos."
+        },
+        {
+          "title": "Beautiful temple",
+          "text": "Really beautiful temple. We got here at 6p when they were reopening. They had just finished blessing a number of the statues and were playing a drum with their fingers and long glue type instrument. All the paintings and statues were very colorful. Worth a stop if you are in the area."
+        }
+      ],
+      "description": "Singapore’s oldest Hindu temple is also one of the most popular thanks to its proximity to Chinatown and its colorful exterior. Admission is free, though a donation is requested of those taking photographs. An annual fire-walking ceremony is held here every October or November.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d324753-Reviews-Sri_Mariamman_Temple-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "244 South Bridge Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "058793",
+        "address_string": "244 South Bridge Road, Singapore 058793 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.282658",
+      "longitude": "103.84531",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6223 4064",
+      "website": "http://smt.org.sg/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d324753-Sri_Mariamman_Temple-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#83 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "83"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "1049",
+      "review_rating_count": {
+        "1": "7",
+        "2": "27",
+        "3": "220",
+        "4": "527",
+        "5": "268"
+      },
+      "photo_count": "1648",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d324753-m66827-Reviews-Sri_Mariamman_Temple-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0700"
+            },
+            "close": {
+              "day": 1,
+              "time": "1130"
+            }
+          },
+          {
+            "open": {
+              "day": 1,
+              "time": "1800"
+            },
+            "close": {
+              "day": 1,
+              "time": "2045"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0700"
+            },
+            "close": {
+              "day": 2,
+              "time": "1130"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1800"
+            },
+            "close": {
+              "day": 2,
+              "time": "2045"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0700"
+            },
+            "close": {
+              "day": 3,
+              "time": "1130"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1800"
+            },
+            "close": {
+              "day": 3,
+              "time": "2045"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0700"
+            },
+            "close": {
+              "day": 4,
+              "time": "1130"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1800"
+            },
+            "close": {
+              "day": 4,
+              "time": "2045"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0700"
+            },
+            "close": {
+              "day": 5,
+              "time": "1130"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1800"
+            },
+            "close": {
+              "day": 5,
+              "time": "2045"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0700"
+            },
+            "close": {
+              "day": 6,
+              "time": "1130"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1800"
+            },
+            "close": {
+              "day": 6,
+              "time": "2045"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0700"
+            },
+            "close": {
+              "day": 7,
+              "time": "1130"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1800"
+            },
+            "close": {
+              "day": 7,
+              "time": "2045"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 07:00 - 11:30,  18:00 - 20:45",
+          "Tuesday: 07:00 - 11:30,  18:00 - 20:45",
+          "Wednesday: 07:00 - 11:30,  18:00 - 20:45",
+          "Thursday: 07:00 - 11:30,  18:00 - 20:45",
+          "Friday: 07:00 - 11:30,  18:00 - 20:45",
+          "Saturday: 07:00 - 11:30,  18:00 - 20:45",
+          "Sunday: 07:00 - 11:30,  18:00 - 20:45"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Sacred & Religious Sites",
+              "localized_name": "Sacred & Religious Sites"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622374",
+          "name": "Outram"
+        },
+        {
+          "location_id": "15622676",
+          "name": "Central Business District"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291616",
+          "name": "Chinatown"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "21"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "324"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "188"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "198"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "156"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "244 South Bridge Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "058793",
+        "address_string": "244 South Bridge Road, Singapore 058793 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Armenian Church in Singapore": [
+    {
+      "location_id": "310895",
+      "name": "Armenian Church Singapore",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/08/b6/14/c9/brisk-and-clear-day.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/08/b6/14/ca/light-up-festival.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/08/b8/06/32/night-festival-2015.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/08/b8/06/31/candles.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/08/b8/06/30/night-festival-2015.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Pretty church but a bit plain.",
+          "text": "I almost walked past this church by accident as the entrance is easy to miss but decided to stop in. Its nice and tranquil in here but having been to Armenia itself it's a bit of a disappointing experience. In Yerevan you would see lots of religious paintings and frescoes inside and there would be the smell of incense. This was largely plain white and no orthodox dome. Pop in and light a candle but dont worry if you miss it."
+        },
+        {
+          "title": "Oldest Church in Singapore",
+          "text": "The Church is dedicated to St. Gregory and dates to 1855, the oldest church in Singapore and designed by Irish architect, George D. Coleman. Very impressive exterior with the Doric columns, balustrades, porticos and the tall spire atop. The interior has a vaulted ceiling with the cupola based on traditional Armenian architecture. Enjoyed the Memorial Gardens, Memorial Cemetry and the various statuary throughout the grounds."
+        },
+        {
+          "title": "Lovely",
+          "text": "I personally liked this cute and compact church and the garden around. An evening stroll around this church would be a perfect idea to feel good and calm."
+        },
+        {
+          "title": "Armenian church of Singapore.",
+          "text": "The Armenian Church of Saint Gregory the Illuminator is the oldest Christian church in Singapore, located at Hill Street in the Museum Planning Area."
+        },
+        {
+          "title": "Oldest Church in Singapore",
+          "text": "At the base of Ft. Canning hill in the colonial district you will find the oldest church in Singapore just edging out St. Andrews.  Built in 1835 shortly after the creation of Singapore, it is an Armenian Church and built in Greek revival style, beautifully painted clean, white.  Its exterior looks like so many early 19th Century churches in the US.  However, inside it is a very interesting circular nave and sanctuary, still in a very historic setting.  While we peeked in we could not take pictures due to an event.  However it is a great structure to visit.  Exterior alone is beautiful."
+        }
+      ],
+      "description": "Take a walk in the lush gardens of the Armenian Church before entering the church and admire the exterior architecture. Breathing history and rich heritage the Armenian Church of St. Gregory the Illuminator is the oldest Church of Singapore and is a gazetted National Monument.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d310895-Reviews-Armenian_Church_Singapore-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "60 Hill St.",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179366",
+        "address_string": "60 Hill St., Singapore 179366 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.293135",
+      "longitude": "103.84932",
+      "timezone": "Asia/Singapore",
+      "email": "weddings@armeniansinasia.org",
+      "phone": "+65 6334 0141",
+      "website": "http://www.armeniansinasia.org",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d310895-Armenian_Church_Singapore-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#139 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "139"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "117",
+      "review_rating_count": {
+        "1": "0",
+        "2": "2",
+        "3": "21",
+        "4": "51",
+        "5": "43"
+      },
+      "photo_count": "268",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d310895-m66827-Reviews-Armenian_Church_Singapore-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0900"
+            },
+            "close": {
+              "day": 1,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0900"
+            },
+            "close": {
+              "day": 2,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0900"
+            },
+            "close": {
+              "day": 3,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0900"
+            },
+            "close": {
+              "day": 4,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0900"
+            },
+            "close": {
+              "day": 5,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0900"
+            },
+            "close": {
+              "day": 6,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0900"
+            },
+            "close": {
+              "day": 7,
+              "time": "1800"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 09:00 - 18:00",
+          "Tuesday: 09:00 - 18:00",
+          "Wednesday: 09:00 - 18:00",
+          "Thursday: 09:00 - 18:00",
+          "Friday: 09:00 - 18:00",
+          "Saturday: 09:00 - 18:00",
+          "Sunday: 09:00 - 18:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Churches & Cathedrals",
+              "localized_name": "Churches & Cathedrals"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622372",
+          "name": "Museum"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        },
+        {
+          "location_id": "15622424",
+          "name": "Bras Basah"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "2"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "21"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "49"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "12"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "14"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "60 Hill St.",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179366",
+        "address_string": "60 Hill St., Singapore 179366 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "CHIJMES Singapore": [
+    {
+      "location_id": "338376",
+      "name": "Chijmes",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/05/99/c5/8a/chijmes.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/2f/e7/f0/chijmes.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/06/e9/05/f4/chijmes.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/06/e9/05/ec/chijmes.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/06/e9/05/d8/chijmes.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "170+ years Chijmes",
+          "text": "CHIJMES was originally known as the Convent of the Holy Infant Jesus (CHIJ), a prestigious girls’ school established in 1854 by a group of French Catholic nuns. With over 170 years of history, it has evolved into one of Singapore’s top destinations for F&B, entertainment, and lifestyle experiences. On top of that, is also become a very popular destination for tourists!"
+        },
+        {
+          "title": "Neogothic design once a convent",
+          "text": "This houses a unique dining experience. It may be spelt Chijmes. It is located in old Singapore. It has some unique restaurants"
+        },
+        {
+          "title": "Chijmes was a convent that had been converted into an assortment of outstanding restaurants and bars.",
+          "text": "We recently stayed for a few days in Singapore and had breakfast in Chijmes each day. The cafe opens at 8.00am unlike most others around that open at 10.00. It is not cheap but cheaper than eating at a hotel and comparable to Perth prices. They have a reasonable menu. The other restaurants and bars in the complex are terrific. There are two Indian restaurants, several bars at ground level and a few modern cuisine restaurants. The only let down is that there are not many toilets and finding them can be fun. Don’t wait to go until you are busting."
+        },
+        {
+          "title": "Do not miss this place on your SG trip",
+          "text": "- Definitely a fun place to hang out and chill after a busy day\n- Establishments are on the pricier side, but you get what you paid for\n- A must-see / must-visit place on your itinerary, especially if you love the Crazy Rich Asian movie"
+        },
+        {
+          "title": "Beautiful old church",
+          "text": "Well developed area that has kept its character. Over 2 levels and full of bars and restaurants. Great location that gets busy and is popular at peak times"
+        }
+      ],
+      "description": "CHIJMES (pronounced “chimes”) stands for the Convent of the Holy Infant Jesus, a Neo-Classical style building which houses one of Singapore’s most aesthetically-pleasing dining and entertainment venues.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d338376-Reviews-Chijmes-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "30 Victoria Street",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "187996",
+        "address_string": "30 Victoria Street, Singapore 187996 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.295304",
+      "longitude": "103.85178",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6265 3600",
+      "website": "http://www.chijmes.com.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d338376-Chijmes-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#51 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "51"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "787",
+      "review_rating_count": {
+        "1": "14",
+        "2": "19",
+        "3": "106",
+        "4": "363",
+        "5": "285"
+      },
+      "photo_count": "1062",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d338376-m66827-Reviews-Chijmes-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Historic Sites",
+              "localized_name": "Historic Sites"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622412",
+          "name": "City Hall"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "39"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "199"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "80"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "95"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "164"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "30 Victoria Street",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "187996",
+        "address_string": "30 Victoria Street, Singapore 187996 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "St Andrewâ€™s Cathedral- Singapore Architecture Landmark": [
+    {
+      "location_id": "446427",
+      "name": "St Andrew's Cathedral",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0c/bf/a4/9c/st-andrew-s-cathedral.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/da/4a/39/st-andrew-s-cathedral.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/da/4a/30/st-andrew-s-cathedral.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/41/4d/01/st-andrew-s-cathedral.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/da/4a/32/st-andrew-s-cathedral.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Nice architecture, music is lacking",
+          "text": "I like the architecture and the vastness of the cathedral. Sadly the worship and music are really lacking compared to elsewhere in the world."
+        },
+        {
+          "title": "A beautiful iconic building",
+          "text": "A beautiful iconic building set in lovely grounds. It has high vaulted ceilings and ornate stained glass. However, if you are used to European style cathedrals you may feel a little underwhelmed."
+        },
+        {
+          "title": "Experienced a Cantonese language Service.",
+          "text": "Closed for renovations when we visited in 2023, still some exterior sections shrouded in scaffold and cloth protection, but the interior was accessible. A number of people present, including clergy and assistants. We decided to sit awhile and view the interior and salve our curiosity of the activities. We were eventually advised that a service in the Cantonese language was about to commence and welcome to remain. Although the language was alien to us, many of the hymns and services were recognisable.\nThe present building dates to 1856 and consecrated in 1862. Built in the neo-Gothic architectural style, it replaced the earlier church which had its foundations laid in 1835. The Cathedral was declared a national monument in 1973."
+        },
+        {
+          "title": "How do they keep it so perfectly white?",
+          "text": "An immaculately white building.  Stunning to look at. The inside is quite a contrast, with its blue decor. Well worth popping in to."
+        },
+        {
+          "title": "Short walk away from the central part of Singapore - worth the visit for a beautiful cathedral",
+          "text": "Beautiful cathedral not too far from the Merlion Park, it was a nice walk in this area, worth the stop and some peace and quiet inside to enjoy the historical church.\n\nThere was some construction around the perimeter, so it took us a minute to find the entrance in.  We walked right by the car entrance gate.  We enjoyed the stained glass work inside, as well as the beautiful arch entrance.\n\nNear the entrance there was a really nice and clean restroom facility.  Definitely worth our brief visit."
+        }
+      ],
+      "description": "St Andrew’s Cathedral is one of Singapore’s most treasured works of architecture. Gazetted as a national monument on 1973, you’ll stand in awe at its majestic facade, with extended pinnacles and a glossy white exterior. Take a coffee break and enjoy our free wifi at The Cathedral Cafe which is conveniently located beside the City Hall MRT entrance (North Bridge Road).",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d446427-Reviews-St_Andrew_s_Cathedral-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "11 St. Andrew's Road",
+        "street2": "St Andrew’s Cathedral",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "178959",
+        "address_string": "11 St. Andrew's Road St Andrew’s Cathedral, Singapore 178959 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.292488",
+      "longitude": "103.85232",
+      "timezone": "Asia/Singapore",
+      "email": "info@cathedral.org.sg",
+      "phone": "+65 6337 6104",
+      "website": "http://www.cathedral.org.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d446427-St_Andrew_s_Cathedral-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#81 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "81"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "412",
+      "review_rating_count": {
+        "1": "3",
+        "2": "7",
+        "3": "85",
+        "4": "210",
+        "5": "107"
+      },
+      "photo_count": "707",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d446427-m66827-Reviews-St_Andrew_s_Cathedral-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0730"
+            },
+            "close": {
+              "day": 1,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0730"
+            },
+            "close": {
+              "day": 2,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0730"
+            },
+            "close": {
+              "day": 3,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0730"
+            },
+            "close": {
+              "day": 4,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0730"
+            },
+            "close": {
+              "day": 5,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0730"
+            },
+            "close": {
+              "day": 6,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0730"
+            },
+            "close": {
+              "day": 7,
+              "time": "1800"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 07:30 - 18:00",
+          "Tuesday: 07:30 - 18:00",
+          "Wednesday: 07:30 - 18:00",
+          "Thursday: 07:30 - 18:00",
+          "Friday: 07:30 - 18:00",
+          "Saturday: 07:30 - 18:00",
+          "Sunday: 07:30 - 18:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Churches & Cathedrals",
+              "localized_name": "Churches & Cathedrals"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622412",
+          "name": "City Hall"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "6"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "128"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "102"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "42"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "51"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "11 St. Andrew's Road",
+        "street2": "St Andrew’s Cathedral",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "178959",
+        "address_string": "11 St. Andrew's Road St Andrew’s Cathedral, Singapore 178959 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Kreta Ayer Square": [
+    {
+      "location_id": "11535911",
+      "name": "Kreta Ayer Square",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0d/84/eb/1e/kreta-ayer-square.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0d/84/eb/8d/kreta-ayer-square.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/26/75/ad/20/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/26/75/ad/1f/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/26/75/ad/1e/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Not much to see",
+          "text": "We visited the temple which is in this square. There isn't really much here and it isn't overly clean. The surrounding area has shops and restaurants which is better to see. It seems to be a performance area and didn't seem to be very busy."
+        },
+        {
+          "title": "Square with a crowd",
+          "text": "Shame it isn’t as clean as the temple. The trash smells awful and there is all kinds of dirt around. The graffiti is interesting. "
+        },
+        {
+          "title": "Center of Chinatown",
+          "text": "Other than being pretty much in the center of Chinatown, there isn’t anything special to see and do here. "
+        },
+        {
+          "title": "Not much to see here ",
+          "text": "The square itself is pretty poor. Not much to see. Of more interest is the nearby temple building or the Chinatown Complex if you’re looking for food."
+        },
+        {
+          "title": "A plaza in Chinatown",
+          "text": "Kreta Ayer Square is located almost in the centre of Chinatown and just behind the Buddha Tooth Relic Temple.\n\nA good stop within the square is the Chinatown Visitor Information centre which provides useful information on many Chinatown attractions and events.\n\nOther attractions surrounding the square is the People’s theatre where you can view cultural music, shows and dance performances during specific times of the year and also local shops and restaurants."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d11535911-Reviews-Kreta_Ayer_Square-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Trengganu Street",
+        "city": "Singapore",
+        "country": "Singapore",
+        "address_string": "Trengganu Street, Singapore Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.28271",
+      "longitude": "103.84402",
+      "timezone": "Asia/Singapore",
+      "website": "http://chinatownfestivals.sg/event/nightly-stage-show",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d11535911-Kreta_Ayer_Square-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#852 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "852"
+      },
+      "rating": "3.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.0-66827-5.svg",
+      "num_reviews": "10",
+      "review_rating_count": {
+        "1": "0",
+        "2": "2",
+        "3": "7",
+        "4": "0",
+        "5": "1"
+      },
+      "photo_count": "23",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d11535911-m66827-Reviews-Kreta_Ayer_Square-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Scenic Walking Areas",
+              "localized_name": "Scenic Walking Areas"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622374",
+          "name": "Outram"
+        },
+        {
+          "location_id": "15622676",
+          "name": "Central Business District"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291616",
+          "name": "Chinatown"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "3"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "4"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "0"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "2"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "Trengganu Street",
+        "city": "Singapore",
+        "country": "Singapore",
+        "address_string": "Trengganu Street, Singapore Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Albert Mall Trishaw Park": [
+    {
+      "location_id": "10088143",
+      "name": "Albert Mall",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0f/ee/b4/fc/photo0jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0c/d6/57/59/signboard-information.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/14/56/8a/e7/street-map.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/14/56/8a/54/street-sign.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/eb/f3/f1/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Super busy eating hall",
+          "text": "Lots of Asian foods available here at very reasonable prices. Try the fried carrot cake which actually has eggs in it for some protein. Quite delicious with onions. Dark carrot cake is the same as the white version with soy sauce added."
+        },
+        {
+          "title": "Very enjoyable “mall” of private stalls selling all sorts of “stuff”",
+          "text": "We have been to the Bugis Street market many times in the past but this mall is new to us.  It is not a mall per se but a collection of different outdoor stalls and stands selling flowers, clothing, and odds and ends.  It is a good adjunct to Bugis Street shopping and is just across the street!"
+        },
+        {
+          "title": "Very busy and exciting mall",
+          "text": "Worth hunting this out. Many temples and people selling lotus flowers. Start of Princess Lane runs off this mall. Saw this from the Mercure Hotel. Runs paralell to Queen Street."
+        },
+        {
+          "title": "Average and ordinary spot",
+          "text": "I was staying in the Ibis hotel nearby, and crossed this spot everyday during my holidays in Singapore city. It is okay, more of a gateway street to local Buddhist and other religious locations, as well as being on the way to Bugis Street and junction."
+        },
+        {
+          "title": "Just food centre",
+          "text": "Not much in mall as attractions,lots of street sellers but food court is where go for cheap inexpensive food "
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d10088143-Reviews-Albert_Mall-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Albert St.",
+        "street2": "Waterloo St.",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "189971",
+        "address_string": "Albert St. Waterloo St., Singapore 189971 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.30336",
+      "longitude": "103.85178",
+      "timezone": "Asia/Singapore",
+      "website": "https://www.ura.gov.sg/skyline/skyline02/skyline02-04/text/changingfaces4.html",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d10088143-Albert_Mall-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#737 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "737"
+      },
+      "rating": "3.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.0-66827-5.svg",
+      "num_reviews": "17",
+      "review_rating_count": {
+        "1": "1",
+        "2": "1",
+        "3": "10",
+        "4": "4",
+        "5": "1"
+      },
+      "photo_count": "50",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d10088143-m66827-Reviews-Albert_Mall-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622483",
+          "name": "Bencoolen"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "5"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "6"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "3"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "1"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "Albert St.",
+        "street2": "Waterloo St.",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "189971",
+        "address_string": "Albert St. Waterloo St., Singapore 189971 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Chinatown Food Street": [
+    {
+      "location_id": "317415",
+      "name": "Chinatown",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/1b/73/65/d0/photo9jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/00/18/cc/98/streets-of-chinatown.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/24/c5/ce/1f/per-le-vie-di-chinatown.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/24/c5/cd/f7/per-le-vie-di-chinatown.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/24/c5/cd/d6/per-le-vie-di-chinatown.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Chinatown ",
+          "text": "It is easy to get to using the MRT and a good place to have a wander around for an hour or two. There are plenty of souvenir shops at reasonable prices. Loads of restaurants and bars to choose from. Some great temples for those photo opportunities."
+        },
+        {
+          "title": "Typical Chinatown",
+          "text": "Some of the old historic buildings were nice. But, all the stalls selling souvenirs were similar. It’s a typical Chinatown with some street foods and cheap trinkets. The Buddha Tooth Relic Temple is the highlight here!"
+        },
+        {
+          "title": "Chinatown for heritage & shopping bargains",
+          "text": "We had visited the large Buddhist temple when we realised on leaving the temple we were literally around the corner from Chinatown and all the shopping stalls and colourful heritage buildings. \n\nThe markets can be and were super crowded with a huge variety of items for sale. This is the cheapest place in all of Singapore for souveniers. I wish we had known about it at the start of our holiday rather than the end of it. This still did not stop us from buying up lots of little presents. \n\nWe even found a place to sit down and have some lunch. A visit to Chinatown should be a must and it is well worth the crowds to get those bargains."
+        },
+        {
+          "title": "A do not miss spot to experience Singapore ",
+          "text": "Fantastic spot to be in Singapore, still has the old heart of Singapore ticking, authentic shopping and amazing dining options, great area that you felt safe in, and could enjoy wandering around in for hours, we visited close to Chinese New Year, so had that extra decorated excitement you would expect "
+        },
+        {
+          "title": "Merely a tourist place",
+          "text": "It might have had some charme years ago but today it is merely a tourist place with lot of shops selling a lot souvenirs but honestly nothing interesting in it"
+        }
+      ],
+      "description": "For a fascinating peek into Singapore’s Chinese culture and history, Chinatown is good place to start. Here, you’ll enjoy a mix of heritage visits to museums, shopping as well as a good variety of food options, sure to leave a traveller happy and satisfied at the end of the day.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d317415-Reviews-Chinatown-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Crot",
+        "street2": "Trengganu",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "048942",
+        "address_string": "Crot Trengganu, Singapore 048942 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.281539",
+      "longitude": "103.84472",
+      "timezone": "Asia/Singapore",
+      "website": "http://www.chinatown.sg/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d317415-Chinatown-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#12 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "12"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "14606",
+      "review_rating_count": {
+        "1": "122",
+        "2": "311",
+        "3": "2295",
+        "4": "6255",
+        "5": "5623"
+      },
+      "photo_count": "11454",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d317415-m66827-Reviews-Chinatown-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0800"
+            },
+            "close": {
+              "day": 1,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0800"
+            },
+            "close": {
+              "day": 2,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0800"
+            },
+            "close": {
+              "day": 3,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0800"
+            },
+            "close": {
+              "day": 4,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0800"
+            },
+            "close": {
+              "day": 5,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0800"
+            },
+            "close": {
+              "day": 6,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0800"
+            },
+            "close": {
+              "day": 7,
+              "time": "0000"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 08:00 - 00:00",
+          "Tuesday: 08:00 - 00:00",
+          "Wednesday: 08:00 - 00:00",
+          "Thursday: 08:00 - 00:00",
+          "Friday: 08:00 - 00:00",
+          "Saturday: 08:00 - 00:00",
+          "Sunday: 08:00 - 00:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "other",
+          "localized_name": "Other"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Neighborhoods",
+              "localized_name": "Neighborhoods"
+            }
+          ]
+        },
+        {
+          "name": "Other",
+          "localized_name": "Other",
+          "categories": [
+            {
+              "name": "Neighborhoods",
+              "localized_name": "Neighborhoods"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622374",
+          "name": "Outram"
+        },
+        {
+          "location_id": "15622676",
+          "name": "Central Business District"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291616",
+          "name": "Chinatown"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "548"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "5064"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "1578"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "2573"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "2264"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "TopAttractions"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        },
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "Crot",
+        "street2": "Trengganu",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "048942",
+        "address_string": "Crot Trengganu, Singapore 048942 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Chinatown Heritage Centre, Singapore": [
+    {
+      "location_id": "324540",
+      "name": "Chinatown Heritage Centre",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/a3/57/03/photo0jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/ee/f8/75/user-review-upload.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/67/ec/fe/chinatown-heritage-centre.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/34/24/35/chinatown-heritage-centre.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/34/24/34/chinatown-heritage-centre.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A captivating journey into the history of Singapore's shop houses and the people who lived in them",
+          "text": "A fantastic journey through the lives of coolies, majies, shopkeepers, doctors, carpenters, story tellers and all the people who created and lived in the shop houses of China Town in Singapore. It's an incredible museum full of fascinating information and stories, all presented as a captivating journey as you walk through the rooms and stairwells of a shop house. I highly recommend visiting here."
+        },
+        {
+          "title": "Worth a visit!",
+          "text": "Very interesting museum. Worth a visit to understand the life of Chinese immigrants in Singapore. The reconstituted lodging back then is impressive.\nGo, go, go!"
+        },
+        {
+          "title": "Realities of life of the Coolie in the 1800 and 1900s and why they came to Singapore",
+          "text": "A real must for those who are interested in understanding the creation of Singapore. You can see the living conditions within the “Shop houses” (whole families in one room) on the first two floors then well designed presentations on the 3rd floor. Well worthwhile and very humbling."
+        },
+        {
+          "title": "An excellent introduction to life in Chinatown",
+          "text": "A really amazing insight into life in the cramped conditions in Chinatown.    Excellent displays and explanations.    The staff were really welcoming and helpful.  We spent much longer than we intended as there was so much to see."
+        },
+        {
+          "title": "Interesting",
+          "text": "Really interesting heritage museum. Very small, quick and easy to get around but worth it to understand the heritage of Singapore. "
+        }
+      ],
+      "description": "Nestled in the vibrant streets of Singapore’s Chinatown, the Chinatown Heritage Centre comprises three beautifully restored shophouses across three levels, serving as your gateway to the rich stories, spirited culture, and resilience of the community that shaped this historic district. It is the only place in Singapore that has meticulously recreated the original interiors of its 1950s shophouse tenants, offering an authentic glimpse into the lives of Chinatown's early residents. Through immersive exhibits, poignant narratives, and vibrant programs, the CHC brings Chinatown's colourful past to life, showcasing the area's dynamic evolution and connecting its history with the present.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d324540-Reviews-Chinatown_Heritage_Centre-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "48 Pagoda Street",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "059207",
+        "address_string": "48 Pagoda Street, Singapore 059207 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.283395",
+      "longitude": "103.844376",
+      "timezone": "Asia/Singapore",
+      "email": "info@chinatownheritagecentre.com.sg",
+      "website": "https://www.chinatownheritagecentre.com.sg/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d324540-Chinatown_Heritage_Centre-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#18 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "18"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "1105",
+      "review_rating_count": {
+        "1": "9",
+        "2": "10",
+        "3": "68",
+        "4": "299",
+        "5": "719"
+      },
+      "photo_count": "754",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d324540-m66827-Reviews-Chinatown_Heritage_Centre-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 19:00",
+          "Tuesday: 10:00 - 19:00",
+          "Wednesday: 10:00 - 19:00",
+          "Thursday: 10:00 - 19:00",
+          "Friday: 10:00 - 19:00",
+          "Saturday: 10:00 - 19:00",
+          "Sunday: 10:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Specialty Museums",
+              "localized_name": "Specialty Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622374",
+          "name": "Outram"
+        },
+        {
+          "location_id": "15622676",
+          "name": "Central Business District"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291616",
+          "name": "Chinatown"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "25"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "380"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "182"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "186"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "135"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "48 Pagoda Street",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "059207",
+        "address_string": "48 Pagoda Street, Singapore 059207 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Thian Hock Keng Temple, Singapore": [
+    {
+      "location_id": "317402",
+      "name": "Thian Hock Keng Temple",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/ad/b9/74/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/98/87/2d/img-20180410-150217-largejpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/67/7e/71/outside-view.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1a/dc/8c/19/thuan-hock-kent-temple.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/68/1c/2c/thian-hock-keng-temple.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Beautiful!",
+          "text": "Very interesting temple. I wish there was more information about it. The building is very colourful and the intricate carvings are mind blowing"
+        },
+        {
+          "title": "Unexpected but delightful introduction to a southern Chinese Temple on the edge of Singapore’s CDB.",
+          "text": "Review of Thian Hock Keng Temple, 158 Telok Ayer Street, Singapore\n\nExit Telok Ayer MRT station on the corner of the intersection with Cross Street and head south along Telok Ayer Street (towards the Amoy Street Food Centre). Stay on the same side of the street. You’re heading towards the high-rise buildings of the modern CBD along what used to be the extent of the original shoreline.\n\nFive minutes/170 m later the road opens out with three-story early 20th C. buildings on both sides of the road until you arrive opposite Thian Hock Keng Temple. There’s this gorgeous completely out-of-place Chinese architectural structure lining the other side of the street with a wavy roofline seemingly imitating the surf that once pounded the beaches hereabouts. The colours are all green and gold and match the handful of trees along the street. Ornamental dragons dance along the apex of the roof symbolising the justice, power and strength of the Temple.\n\nThere’s a description of the Temple attached to the wall that provides some historical background. It also gives that raison d’être for being there; Chinese migrants arriving safely in sea vessels at their first place of embarkation >200 years ago and pleased to give thanks to the Sea Goddess Mazu. Stories and legends relate to the cult of Mazu/Mazuism from the 12th C. on with the majority of modern followers based upon the coastal Chinese province of Fuji and migrant communities in SE Asia – particularly the island of Taiwan.\n\nThe Temple of Heavenly Happiness (in English translation) was first established in 1821 in a joss house – a simple hut built of local materials before the dedicated temple building was constructed 20 years later. Regular investment with rebuilding, renovation and maintenance followed during the next 180 years with support from local communities. In turn, the original buildings were used for community, social and educational purposes as Singapore developed. The Temple was substantially renovated 25 years ago – such that it gained UNESCO heritage recognition. On 06 July 1973 – 50 years ago – the Temple was gazetted a National Monument.\n\nInside and out, the design and decorative nature of the buildings overwhelm visitors unfamiliar with temples. The Temple has a traditional three-hall design – Entrance, Main and Rear. Enter by the main door off the street – with a small door on either side – into the Entrance Hall and through into the Main Hall. Here is where you find the shrine of Mazu with a supportive deity on either side. This is where the majority of worshippers gather.\n\nTake time to wander the courtyard at the rear including the two covered walkways opposite one to the other – carved pillars, decorated ceilings with hanging lights and floors with patterned tiles. Everything clean, well-presented and brilliantly coloured – reflecting original classical Southern Chinese architecture. On either side of the temple are pagodas.\n\nThe temple overwhelms with the intricate detail of design, construction and meaning – much of this based upon the concept of feng shui. This is a Chinese system for positioning a building and the objects within the building such that they agree with the associated spiritual forces which brings health and happiness to believers. Scattered around the temple are several shrines dedicated to different deities, and side halls available for private meditation.\n\nWe had the Temple largely to ourselves – there were a few visitors most of whom appeared to be slowly wandering around. The place was peaceful/quiet, but you could pick up the noise from the commercial shops, vehicles and people outside on Telok Ayer Street.\n\nIt had been an interesting visit – typical of the uninitiated. It would have been useful to have had a pamphlet or guidebook to provide an introduction to those of us unfamiliar with the design, purpose, objectivity/meaning of the different features, etc. within the Temple.\n\nPeter Steele\n11 October 2024"
+        },
+        {
+          "title": "Taoist (Buddhism) Temple in Singapore",
+          "text": "The Thian Hock Keng is a Taoist  Temple. It is the oldest one remaining in Singapore. It is still actively used by the Hokkien People (Chinese)"
+        },
+        {
+          "title": "Stunning building.",
+          "text": "Beautiful building just by turning a street and this is just so special and makes you want to stop, take a moment to look and relax and appreciate this amazing building. Take your time and enjoy the peace this temple brings before leaving and returning to the city hustle and bustle."
+        },
+        {
+          "title": "Peaceful spot",
+          "text": "As we wandered through Chinatown and down the hill from Ann Siang Hill Park we happened upon this peaceful temple on a busy little street. It’s always nice to step inside temples and feel whisked away to another time. Very colorful, well kept, and quiet."
+        }
+      ],
+      "description": "The Thian Hock Keng Temple was erected in 1821 by seamen grateful for safe passage, and stands where Singapore's waterfront used to be, before the land was reclaimed.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d317402-Reviews-Thian_Hock_Keng_Temple-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "158 Telok Ayer Street",
+        "street2": "Chinatown",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "068613",
+        "address_string": "158 Telok Ayer Street Chinatown, Singapore 068613 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.281007",
+      "longitude": "103.84756",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6423 4616",
+      "website": "https://thianhockkeng.com.sg/site/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d317402-Thian_Hock_Keng_Temple-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#66 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "66"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "320",
+      "review_rating_count": {
+        "1": "0",
+        "2": "2",
+        "3": "57",
+        "4": "165",
+        "5": "96"
+      },
+      "photo_count": "755",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d317402-m66827-Reviews-Thian_Hock_Keng_Temple-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0730"
+            },
+            "close": {
+              "day": 1,
+              "time": "1730"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0730"
+            },
+            "close": {
+              "day": 2,
+              "time": "1730"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0730"
+            },
+            "close": {
+              "day": 3,
+              "time": "1730"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0730"
+            },
+            "close": {
+              "day": 4,
+              "time": "1730"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0730"
+            },
+            "close": {
+              "day": 5,
+              "time": "1730"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0730"
+            },
+            "close": {
+              "day": 6,
+              "time": "1730"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0730"
+            },
+            "close": {
+              "day": 7,
+              "time": "1730"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 07:30 - 17:30",
+          "Tuesday: 07:30 - 17:30",
+          "Wednesday: 07:30 - 17:30",
+          "Thursday: 07:30 - 17:30",
+          "Friday: 07:30 - 17:30",
+          "Saturday: 07:30 - 17:30",
+          "Sunday: 07:30 - 17:30"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Sacred & Religious Sites",
+              "localized_name": "Sacred & Religious Sites"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622374",
+          "name": "Outram"
+        },
+        {
+          "location_id": "15622676",
+          "name": "Central Business District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "4"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "97"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "78"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "47"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "40"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "158 Telok Ayer Street",
+        "street2": "Chinatown",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "068613",
+        "address_string": "158 Telok Ayer Street Chinatown, Singapore 068613 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Eurasian Heritage Centre: Singapore Attraction": [
+    {
+      "location_id": "3459646",
+      "name": "Eurasian Heritage Gallery",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/c5/4c/90/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/c5/4e/f0/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/c5/4f/5e/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/c5/4e/b0/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/c5/4e/54/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A wonderful morning spent soaking up history",
+          "text": "A well planned exhibition of the early days of the Eurasians in Singapore. Found a lot of similarities with the Eurasians families back home in Sri Lanka and our lifestyles.  Well documented and in some instances, new learnings. Well done!"
+        },
+        {
+          "title": "Walking Down Memory Lane at the Eurasian Heritage Gallery",
+          "text": "I came with my sister-in-law (who is a Eurasian) and her children.  She left Singapore for so long. It was our first time visiting the gallery and we enjoyed it!  The journey became alive as my sister-in-law remembered, shared and narrated about the colonial eras of the Portuguese, Dutch and the British with an Asian element to our heritage.  We were immersed in the Eurasian origins, culture, history, traditions, surnames, language – Kristang and food.   \n\nThe gallery is a little off the tourist belt.  If you love history, culture, and curious about Eurasian – It’s No Sweat to You!  Just hop on the mrt, or just do Grab or book a guided tour.  You will enjoy it as it is something different.  After the walk-about, don’t miss to try the Eurasian food at Quentin’s Eurasian restaurant located at the same building.  Enjoy!"
+        },
+        {
+          "title": "Wealth of Information",
+          "text": "Went with a group of friends. Did not have guided tour though. The museum was abit out of the usual tourist haunts, but definitely worth going. Newspapers cutting and lots of photos that shown how the Eurasians stay in Singapore thru the times. Maybe with guided tour, you will enjoy even more. However, walking on our own and reading and viewing the exhibits at own pace does wonders too. Recommended to cater at least 1 hour to walk thru the galleries."
+        },
+        {
+          "title": "Interesting tour with knowledgeable tourguide!",
+          "text": "Nice  tour with knowledgeable tourguide! A nice overview of the role  of  Eurasians (Portugese, British and Dutch roots) in Singapores' history. The \"war room\" is very interesting and showing the hard life under the Japanese occupation. Recommended not only for Eurasians, but for all Singaporeans and Tourists!  "
+        },
+        {
+          "title": "A small but interesting museum",
+          "text": "A bit off the tourist trail, but well worth the trek both to have a meal at Quentin's Eurasian restaurant (see separate review) but also to visit the small but fascinating museum which chronicles the history and background of Eurasians in Singapore; their emergence in the region; and their specific experiences in World War 2 including internship for many civilians in the settlement of Bahau, in the jungles of Malaya."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d3459646-Reviews-Eurasian_Heritage_Gallery-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "139 Ceylon Road Eurasian Community House",
+        "street2": "Eurasian Community House",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "429744",
+        "address_string": "139 Ceylon Road Eurasian Community House Eurasian Community House, Singapore 429744 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.310061",
+      "longitude": "103.89934",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6447 1578",
+      "website": "http://www.eurasians.org.sg/eurasians-in-singapore/eurasian-heritage-gallery/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d3459646-Eurasian_Heritage_Gallery-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#417 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "417"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "14",
+      "review_rating_count": {
+        "1": "0",
+        "2": "0",
+        "3": "4",
+        "4": "6",
+        "5": "4"
+      },
+      "photo_count": "32",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d3459646-m66827-Reviews-Eurasian_Heritage_Gallery-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1700"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: Closed",
+          "Tuesday: 10:00 - 17:00",
+          "Wednesday: 10:00 - 17:00",
+          "Thursday: 10:00 - 17:00",
+          "Friday: 10:00 - 17:00",
+          "Saturday: 10:00 - 17:00",
+          "Sunday: 10:00 - 17:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "History Museums",
+              "localized_name": "History Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622386",
+          "name": "Geylang East"
+        },
+        {
+          "location_id": "7291626",
+          "name": "Joo Chiat"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "2"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "3"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "1"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "4"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "139 Ceylon Road Eurasian Community House",
+        "street2": "Eurasian Community House",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "429744",
+        "address_string": "139 Ceylon Road Eurasian Community House Eurasian Community House, Singapore 429744 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Shophouses": [
+    {
+      "location_id": "22984564",
+      "name": "Figment (peranakan Shophouses)",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/71/4d/c4/still-house-facade.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/71/4d/c8/still-house-interior.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/71/4d/c7/still-house-facade.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/71/4d/c6/shang-house-exterior.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/71/4d/c5/shang-house-interior.jpg"
+      ],
+      "reviews": [],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d22984564-Reviews-Figment_peranakan_Shophouses-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "36 Petain Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "208102",
+        "address_string": "36 Petain Road, Singapore 208102 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.31238",
+      "longitude": "103.85838",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 8726 2162",
+      "website": "http://www.livefigment.com",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d22984564-Figment_peranakan_Shophouses-Singapore.html?m=66827",
+      "num_reviews": "0",
+      "photo_count": "8",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d22984564-m66827-Reviews-Figment_peranakan_Shophouses-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0000"
+            },
+            "close": {
+              "day": 1,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0000"
+            },
+            "close": {
+              "day": 2,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0000"
+            },
+            "close": {
+              "day": 3,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0000"
+            },
+            "close": {
+              "day": 4,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0000"
+            },
+            "close": {
+              "day": 5,
+              "time": "2359"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 00:00 - 23:59",
+          "Tuesday: 00:00 - 23:59",
+          "Wednesday: 00:00 - 23:59",
+          "Thursday: 00:00 - 23:59",
+          "Friday: 00:00 - 23:59",
+          "Saturday: Closed",
+          "Sunday: Closed"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            },
+            {
+              "name": "Monuments & Statues",
+              "localized_name": "Monuments & Statues"
+            },
+            {
+              "name": "Architectural Buildings",
+              "localized_name": "Architectural Buildings"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622656",
+          "name": "Lavender"
+        },
+        {
+          "location_id": "15622361",
+          "name": "Kallang"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "0"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "0"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "0"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "0"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "36 Petain Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "208102",
+        "address_string": "36 Petain Road, Singapore 208102 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Capitol Building Singapore": [
+    {
+      "location_id": "8816162",
+      "name": "Capitol Piazza",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/f0/2f/92/photo1jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/8b/42/90/capitol-piazza-front.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/8b/46/18/luxurious-ambience.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/8b/46/16/luxurious-ambience.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/8b/44/51/inside-capitol-piazza.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "What's happened here?",
+          "text": "Food Republic used to be ond of my favorite food courts but my visit this morning after about half a year's absence left me shocked and dismayed. Most of the popular food stalls have closed since it was Tuesday and not a popular day off. The Taiwanese food stall, Guan mee pok and the chai png stalls were in darkness, leaving the Japanese food outlet very busy. The drinks stall is still there and one selling pohpiah and kueh pie tee, chicken wings. Punggol Nasi Lemak opposite was in full swing. Hmm, such a pity as it was so vibrant before."
+        },
+        {
+          "title": "Nice quiet mall with good restaurants & cafes",
+          "text": "A conveniently located mall near City Hall MRT (there’s a direct link from the station to Basement 2 of Capitol Piazza) filled with many good restaurants in Capitol Arcade & Piazza & a cosy patisserie. \n\nThey are currently having Domes for booking for dining with friends. Very pretty for photos & a cosy dome for small gatherings with friends. Try them! Highly recommended! It’s free with spending at their restaurants! "
+        },
+        {
+          "title": "Quieter than raffles city and city hall ",
+          "text": "Mix of high end , mid range and cheap eats .  There is a famous noodles stall-\nGuan’s Mee pok. Next to it is Punggol nasi lemak. The food option here is rather different from other malls.  There is a food court, burger king, fun toast, toast box, restaurants by kempinski hotel. "
+        },
+        {
+          "title": "Cakes are yummy! At Flor Patisserie ",
+          "text": "The cakes are fabulous!\n\nThe service was reallyyyyy bad!  There were 3 ladies on the staff and they needed to prepare 3 coffees and two teas and it took them over 30 minutes to be ready! \nNoted that we were the only table at the coffee shop! "
+        },
+        {
+          "title": "Food Republic @ Capitol Piazza",
+          "text": "I've been for lunch a few times recently at the Food Republic at Capitol Piazza. This outlet is good as it's usually possible to get a seat without too much effort, even during the busy lunchtime peak period. Each time I've had the wonton noodles - quite tasty and reasonably priced."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d8816162-Reviews-Capitol_Piazza-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "13 Stamford Road Capitol Piazza",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "178905",
+        "address_string": "13 Stamford Road Capitol Piazza, Singapore 178905 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.292961",
+      "longitude": "103.85147",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6499 5168",
+      "website": "http://www.capitolpiazza.com",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d8816162-Capitol_Piazza-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#399 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "399"
+      },
+      "rating": "3.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.5-66827-5.svg",
+      "num_reviews": "46",
+      "review_rating_count": {
+        "1": "3",
+        "2": "2",
+        "3": "21",
+        "4": "12",
+        "5": "8"
+      },
+      "photo_count": "118",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d8816162-m66827-Reviews-Capitol_Piazza-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "shopping",
+          "localized_name": "Shopping"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Shopping",
+          "localized_name": "Shopping",
+          "categories": [
+            {
+              "name": "Shopping Malls",
+              "localized_name": "Shopping Malls"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622412",
+          "name": "City Hall"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "6"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "12"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "12"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "11"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "13 Stamford Road Capitol Piazza",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "178905",
+        "address_string": "13 Stamford Road Capitol Piazza, Singapore 178905 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Esplanade Theatre": [
+    {
+      "location_id": "324752",
+      "name": "Esplanade - Theatres on the Bay",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/18/60/8d/7b/photo5jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/2a/9b/0c/esplanade-theatres-on.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/2a/9c/1e/esplanade-theatres-on.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/2a/9b/cb/esplanade-theatres-on.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/2a/9b/bf/esplanade-theatres-on.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Nice",
+          "text": "The architecture itself is eye candy! The theatres are vibrant, with plenty of shows, restaurants and views of the waterfront."
+        },
+        {
+          "title": "esplanade",
+          "text": "Stopped by here after getting caught in a summer thunderstorm, and ended up catching some talented aerial artists performing!"
+        },
+        {
+          "title": "Great concert experience ",
+          "text": "The sound system and acoustics of Esplanade concert hall were impeccable.\n\nThe seats were pretty comfotable, and the ushers were very proficient"
+        },
+        {
+          "title": "Theatre shows",
+          "text": "It's a place to watch shows and with food outlets. You can also just sit outside and admire the views at night. Walk from there across the bridge to the Merlion Park."
+        },
+        {
+          "title": "Thank you for changing my mind:)",
+          "text": "Walking from Promenade, I saw Esplanade \nI was craving for coconut, but I only saw peanut \nI walked further into Esplanade, and my favourite now is durian :)"
+        }
+      ],
+      "description": "Affectionately known among locals as the \"durian\", Esplanade is one of the busiest arts centres in the world with about 3,000 performances presented yearly. Spot our prickly cladding in the middle of the central arts and cultural district, and take in the view from the Marina bay waterfront where our Outdoor Theatre is situated. Coming to Esplanade means that you're in for a complete lifestyle experience, from enjoying a night out at a show, to shopping and dining. And whether you're a first-timer, an ardent patron or fellow arts lover, you're most welcome here and we'll do our best to give you a great experience with the arts.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d324752-Reviews-Esplanade_Theatres_on_the_Bay-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 Esplanade Drive",
+        "street2": "Floor 1, Esplanade Mall",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "038981",
+        "address_string": "1 Esplanade Drive Floor 1, Esplanade Mall, Singapore 038981 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.28989",
+      "longitude": "103.85517",
+      "timezone": "Asia/Singapore",
+      "email": "mall@esplanade.com",
+      "phone": "+65 6828 8377",
+      "website": "https://www.esplanade.com/whats-on/category?GenreNames=Theatre",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d324752-Esplanade_Theatres_on_the_Bay-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#32 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "32"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "1097",
+      "review_rating_count": {
+        "1": "3",
+        "2": "4",
+        "3": "86",
+        "4": "456",
+        "5": "548"
+      },
+      "photo_count": "780",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d324752-m66827-Reviews-Esplanade_Theatres_on_the_Bay-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "theater_concerts",
+          "localized_name": "Concerts & Shows"
+        },
+        {
+          "name": "activities",
+          "localized_name": "Activities"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            }
+          ]
+        },
+        {
+          "name": "Concerts & Shows",
+          "localized_name": "Concerts & Shows",
+          "categories": [
+            {
+              "name": "Theaters",
+              "localized_name": "Theaters"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622655",
+          "name": "Marina Centre"
+        },
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "41"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "263"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "140"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "220"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "205"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "1 Esplanade Drive",
+        "street2": "Floor 1, Esplanade Mall",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "038981",
+        "address_string": "1 Esplanade Drive Floor 1, Esplanade Mall, Singapore 038981 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Gardens by the Bay": [
+    {
+      "location_id": "2149128",
+      "name": "Gardens by the Bay",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/05/d9/0e/f0/gardens-by-the-bay.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/be/b0/33/gardens-by-the-bay.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/be/ad/12/gardens-by-the-bay.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/04/01/55/ee/gardens-by-the-bay.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/be/b0/39/gardens-by-the-bay.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Impressive but overly-monetized",
+          "text": "Accessed via the dragonfly bridge from Marina Bay Sands or metro to bayfront Gardens by the Bay is a requisite stop for anyone visiting Singapore, the free portion mostly consisting of greenery and elevated platforms while those who want to pay can visit a variety of greenhouses or take an elevator to suspended vantage points including a cafe.  Best visited after sundown when lights turn on and crowds are diminished."
+        },
+        {
+          "title": "Stunning place",
+          "text": "What a beautiful place. You need many hours to walk through the gardens.\nEverything is well looked after. \nEntry is free but if you want to visit the Flower Dome, cloud Forrest or doing the Skywalk it’s an entry fee, but worth it to pay and to see.\nThe super trees are just stunning by day and more stunning at night when the light show begins. It’s also free but be early , it’s packed. \nShow is 7.45 pm and 8.45 pm. Takes approximately 15 min.\nLots of Statues , eateries and restrooms in the park \nMRT is 15 min walk away"
+        },
+        {
+          "title": "Such kind and informative local guides!",
+          "text": "I have yet to write a review on all the wonderful places I've visited but the actions of one kind local guide has inspired me to do so. My husband and I had just about wrapped up our visit to the wonderful cloud forest but we were still clueless on navigating outside the gardens. It was right as we were leaving when we approached a guide, Hazik, who at first seemed at a rush with his clipboard in hand but stopped all he was doing to assist us. He not only kindly explained the directions we requested but started an insightful conversation and even assisted in planning out a detailed itinerary for our brief stay in Singapur. We would like to extend our gratitude for his kindness and patience in guiding us which ultimately was the highlight of our trip to the gardens!"
+        },
+        {
+          "title": "A Dream Fulfilled!!",
+          "text": "THE destination in Singapore! My time in the city was limited, but I still ended up spending basically one entire day roaming the grounds and exploring the different facilities (e.g. Flower Dome, Supertree Grove, Cloud Forest). Tickets are available at various entry points for any or all areas you’d like to see, which, for me, was everything. The cost is pricey but 1000% worth the investment. Multiple food vendors are on the premises. Nearby GBTB (abbreviated name) are Marina Bay Sands (the hotel/casino/shopping mall) and the waterfront promenade, plus a metro station (Bayfront MRT) is connected to everything so one needn’t walk outdoors too much if hot and humid."
+        },
+        {
+          "title": "Lovely walk around. Restaurants and bathrooms",
+          "text": "You need at least two hours here. Be sure to stop on the sixth floor of the marina Bay Sands, Hotel, and then take the escalator down into the gardens so you can take advantage of the views from up there. It is free to go, but there are two gardens that you could pay to enter if you wish."
+        }
+      ],
+      "description": "An integral part of Singapore's \"City in a Garden\" vision, Gardens by the Bay spans a total of 101 hectares of prime land at the heart of Singapore's new downtown - Marina Bay. Comprising three waterfront gardens - Bay South, Bay East and Bay Central - Gardens by the Bay will be a showcase of horticulture and garden artistry that will bring the world of plants to Singapore and present Singapore to the World.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2149128-Reviews-Gardens_by_the_Bay-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "18 Marina Gardens Drive",
+        "street2": "Supertree Grove",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018953",
+        "address_string": "18 Marina Gardens Drive Supertree Grove, Singapore 018953 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.281566",
+      "longitude": "103.86361",
+      "timezone": "Asia/Singapore",
+      "email": "feedback@gardensbythebay.com.sg",
+      "phone": "+65 6420 6848",
+      "website": "http://www.gardensbythebay.com.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2149128-Gardens_by_the_Bay-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#260 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "260"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "61998",
+      "review_rating_count": {
+        "1": "213",
+        "2": "411",
+        "3": "2565",
+        "4": "13971",
+        "5": "44838"
+      },
+      "photo_count": "65497",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2149128-m66827-Reviews-Gardens_by_the_Bay-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0500"
+            },
+            "close": {
+              "day": 1,
+              "time": "0200"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0500"
+            },
+            "close": {
+              "day": 2,
+              "time": "0200"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0500"
+            },
+            "close": {
+              "day": 3,
+              "time": "0200"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0500"
+            },
+            "close": {
+              "day": 4,
+              "time": "0200"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0500"
+            },
+            "close": {
+              "day": 5,
+              "time": "0200"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0500"
+            },
+            "close": {
+              "day": 6,
+              "time": "0200"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0500"
+            },
+            "close": {
+              "day": 7,
+              "time": "0200"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 05:00 - 02:00",
+          "Tuesday: 05:00 - 02:00",
+          "Wednesday: 05:00 - 02:00",
+          "Thursday: 05:00 - 02:00",
+          "Friday: 05:00 - 02:00",
+          "Saturday: 05:00 - 02:00",
+          "Sunday: 05:00 - 02:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            }
+          ]
+        },
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Gardens",
+              "localized_name": "Gardens"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "13210711",
+          "name": "Marina South"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "2280"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "22168"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "5071"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "16283"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "9630"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "TopAttractions"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        },
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "18 Marina Gardens Drive",
+        "street2": "Supertree Grove",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018953",
+        "address_string": "18 Marina Gardens Drive Supertree Grove, Singapore 018953 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "The Interlace": [
+    {
+      "location_id": "25256370",
+      "name": "The Interlace Buildings",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/27/dd/c3/2d/the-interlace-building.jpg"
+      ],
+      "reviews": [],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d25256370-Reviews-The_Interlace_Buildings-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "180 Depot Road #01-02 the Interlace",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "109684",
+        "address_string": "180 Depot Road #01-02 the Interlace, Singapore 109684 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.285801",
+      "longitude": "103.85111",
+      "timezone": "Asia/Singapore",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d25256370-The_Interlace_Buildings-Singapore.html?m=66827",
+      "num_reviews": "0",
+      "photo_count": "1",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d25256370-m66827-Reviews-The_Interlace_Buildings-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Architectural Buildings",
+              "localized_name": "Architectural Buildings"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "0"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "0"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "0"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "0"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "180 Depot Road #01-02 the Interlace",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "109684",
+        "address_string": "180 Depot Road #01-02 the Interlace, Singapore 109684 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "PARKROYAL on Pickering": [
+    {
+      "location_id": "2349039",
+      "name": "St. Gregory Spa - PARKROYAL on Beach Road",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/bb/e6/96/couple-spa-room.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/bb/e6/a8/spa-reception.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/15/32/93/c8/st-gregory-javana-spa.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/15/32/93/c9/st-gregory-javana-spa.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/15/32/93/c7/st-gregory-javana-spa.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Disappointed",
+          "text": "Was extremely disappointed.  The spa services were not as described and the therapists were inexperienced.  The spa was rather cramped and we did not enjoy the services.  For example, the facial did not have the scrub or treatment as described in the menu; the massage was weak and did not hit any pressure points.  The reception area was tiny and when we arrived, the therapists were sprawled on the reception table and sitting in the guest chairs and yakking away.   We were shown t a small lounge which seated 2 when there were 3 of us.  We were served with lukewarm tea and water.  It was altogether an unpleasant experience.  Not recommended at all."
+        },
+        {
+          "title": "Professional Massage service",
+          "text": "I took one hour massage . The service is excellent by Niya who provided professional body and foot massage that alleviated pain in my body and arm muscles . The place is clean and the booking was easy."
+        },
+        {
+          "title": "Brought back to life",
+          "text": "We had the couples massage and it was a truly wonderful experience. My wife chose the soft tissue Balinese massage and I chose the firmer Chinese massage. My therapist Lily was absolutely amazing. She identified every single point of stress in my body and then released it seamlessly. We had just spent 12 days traveling in India with our 3 kids and were beyond exhausted! The treatment we received here was a lifesaver! Definitely recommended."
+        },
+        {
+          "title": "Best massage ever.",
+          "text": "I arrived with ITband really tight but Mae (?) was so skilled at gently starting to work on it (and the rest of me) and then varying pressure until it just let go. I really think this was my best massage ever. And the massage oil was gorgeous."
+        },
+        {
+          "title": "500 Luohan",
+          "text": "A must visit place during your Bintan trip. Impressive statues, each has its own facial expression and posture. A good place for photography whether is for day or nite view. \n Do booked your own transport to come here, no public buses, not public transport friendly.\n\nCan get very hot, do come in the day, open at 9-6pm.\nBring water, hat and sunscreen."
+        }
+      ],
+      "description": "Take a moment to disconnect from the daily hustle and bustle, and retreat into the urban sanctuary at our award-winning hotel spa in Singapore - St. Gregory. St. Gregory spa offers some of the finest Asian treatments giving your body a regeneration that it well deserves amidst the hectic schedule and stresses of life. Highly skilled in-house physicians and therapists are on hand to relieve those knots and tired muscles, promoting good health and overall well-being. Choose from a plethora of treatments including Traditional Chinese Medicine (TCM), Balinese massage and Aromatherapy massages. Elevate your beauty and wellness retreat through an invigorating workout at the hotel's spacious gymnasium with state-of-the-art equipment, or simply practise mindfulness with an instructor-led yoga class in our fitness studio. For the ultimate wellness day-cation, take a dip in our spectacular half Olympic-sized outdoor swimming pool while enjoying scenic views of the city's skyline.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2349039-Reviews-St_Gregory_Spa_PARKROYAL_on_Beach_Road-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "7500 Beach Road Plaza Hotel",
+        "street2": "Level 4 PARKROYAL on Beach Road",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "199593",
+        "address_string": "7500 Beach Road Plaza Hotel Level 4 PARKROYAL on Beach Road, Singapore 199593 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.30009",
+      "longitude": "103.86066",
+      "timezone": "Asia/Singapore",
+      "email": "stgregory.prsin@parkroyalhotels.com",
+      "phone": "+65 6505 5755",
+      "website": "https://www.panpacific.com/en/hotels-and-resorts/pr-beach-road/facilities/st-gregory.html",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2349039-St_Gregory_Spa_PARKROYAL_on_Beach_Road-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#129 of 668 Spas &amp; Wellness in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "668",
+        "ranking": "129"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "8",
+      "review_rating_count": {
+        "1": "0",
+        "2": "1",
+        "3": "0",
+        "4": "0",
+        "5": "7"
+      },
+      "photo_count": "10",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2349039-m66827-Reviews-St_Gregory_Spa_PARKROYAL_on_Beach_Road-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "wellness_spas",
+          "localized_name": "Spas & Wellness"
+        },
+        {
+          "name": "activities",
+          "localized_name": "Activities"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Spas & Wellness",
+          "localized_name": "Spas & Wellness",
+          "categories": [
+            {
+              "name": "Spas",
+              "localized_name": "Spas"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622450",
+          "name": "Crawford"
+        },
+        {
+          "location_id": "15622361",
+          "name": "Kallang"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "1"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "1"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "3"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "1"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "1"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "7500 Beach Road Plaza Hotel",
+        "street2": "Level 4 PARKROYAL on Beach Road",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "199593",
+        "address_string": "7500 Beach Road Plaza Hotel Level 4 PARKROYAL on Beach Road, Singapore 199593 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Lasalle College of the Arts": [
+    {
+      "location_id": "8632133",
+      "name": "Lasalle College of the Arts",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0f/ee/bc/b7/photo3jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/08/fc/8d/3b/lasalle-college-of-the.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-p/1b/27/10/db/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-p/1b/27/10/da/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-p/1b/27/10/d9/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Bad experience",
+          "text": "Bad experience with rude student. Strongly advisable to bring along a 24-7 video camera when you step into the premises. This will definitely assist the school just in case their cctv does not capture their student’s misbehaviour!"
+        },
+        {
+          "title": "Beautiful college",
+          "text": "A great, well maintained college for the Arts. Exclusively meant for Arts students or those students who are interested to learn about arts."
+        },
+        {
+          "title": "Beautiful building, worth visiting if in the vicinity",
+          "text": "The building architecture is amazing and it's worth visiting if you're interested in the arts or are in the area. The college regularly hosts events and concerts. The cafe is public too."
+        },
+        {
+          "title": "Modern design",
+          "text": "This is quite an attractive modern building with some interesting design features. It's worth a wander through if you happen to be in the area, but probably not worth going out of your way specifically to visit. "
+        },
+        {
+          "title": "Made into Singaporean history.",
+          "text": "This school has a long history into the arts of Singapore, it's newly intricate design is a legacy and a great tribute to hit's creator Brother McNally. Even the street bares it's name. I'm very proud that it is now part of Singapore's historical landmark."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d8632133-Reviews-Lasalle_College_of_the_Arts-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 McNally Street Lasalle College of the Arts",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "187940",
+        "address_string": "1 McNally Street Lasalle College of the Arts, Singapore 187940 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.30279",
+      "longitude": "103.85158",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6496 5000",
+      "website": "http://www.lasalle.edu.sg/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d8632133-Lasalle_College_of_the_Arts-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#402 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "402"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "19",
+      "review_rating_count": {
+        "1": "1",
+        "2": "0",
+        "3": "3",
+        "4": "10",
+        "5": "5"
+      },
+      "photo_count": "36",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d8632133-m66827-Reviews-Lasalle_College_of_the_Arts-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Architectural Buildings",
+              "localized_name": "Architectural Buildings"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622483",
+          "name": "Bencoolen"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "1"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "4"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "7"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "3"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "3"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "1 McNally Street Lasalle College of the Arts",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "187940",
+        "address_string": "1 McNally Street Lasalle College of the Arts, Singapore 187940 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Kranji War Memorial Landmark in Singapore": [
+    {
+      "location_id": "386877",
+      "name": "Kranji War Memorial",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/04/a5/a4/34/kranji-war-memorial.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/22/bb/c2/kranji-war-cemetery-entrance.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/05/38/49/76/gravestone-of-dr-benjamin.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/c9/7f/eb/headstones-at-kranji.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/d5/99/8c/kranji-war-memorial.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Emotional and Well Worth Visiting",
+          "text": "I recommend visiting Kranji War Memorial. It is an emotional experience particularly when you are the only visitor in the cemetery. \n\nSeeing the graves of so many young servicemen who lost their lives certainly puts life in perspective. \n\nThere are two cemeteries here - a military one and a civilian one.\n\nThe cemetery is kept in immaculate condition and cared for by dedicated team who work there.\n\nThey were also very helpful and friendly in guiding me to the graves of two former Singaporean Presidents. \n\nI took a taxi from Orchard Road and the journey was about half an hour and cost about $20. I returned on the MRT and it took just under an hour.\n\nI recommend a visit here whether on your own or as part of a tour. I am most grateful to the amazing care takers who take such care of the graves and grounds.\n\nPlease do visit."
+        },
+        {
+          "title": "Sobering",
+          "text": "As with many reviewers, I took the metro to Krangi station and then took the bus two stops to the entrance (definitely easier than walking if it's hot, as it usually will be).  I did not actually see any signs for the cemetery at the bus stop, although they may have existed, but a friendly local pointed out where to go.  It's about a 400 m walk up a sideroad to the entrance to the cemetery.  \n\nIt is huge, and rather heartbreaking when you see the ages of many of the people buried here.  There is also a large pavilion with plaques listing people who were cremated or whose bodies were not located.  The pavilion can be useful for shelter if one of Singapore's frequent but often brief rain showers occurs while you are here!\n\nThe displays and plaques near the entrance were useful to get some idea of Singapore history in WWII, including one which shows the significant battle sites."
+        },
+        {
+          "title": "Very moving place",
+          "text": "For those interested in history and WW2 in particular this is a very moving place to visit. The grounds are maintained to very high standard.   If travelling by Taxi make sure you get the address details correct for both drop off and collection."
+        },
+        {
+          "title": "Paying my respect to the fallen in Singapore ",
+          "text": "We visited on a very hot and humid day so took a taxi from the MRT station which cost $4:80 well worth it. The mamorial is set on a slight incline and a few steps. It was very tranquil with flowers in the middle section, but the outer stones looked a little neglected, but there were staff gradually pressure washing them. But still no flowers. They look so sad!  The fallen deserve so much more?  When we had paid our respect, we headed bach to the MRT station, which is a downhill walk, but across a couple of busy roads. It took about 15 minutes. Well, it's worth a visit if you're interested in the history of Singapore. The MRT  out off the city, and though the suburbs shows how inventive this countrs is to house its population? A thoroughly enjoyable and reflective morning. Remember to take plenty of water. And there are no  facilities, so use the MRTs before you leave there?"
+        },
+        {
+          "title": "Very poignant.",
+          "text": "Visited the Kranji War Memorial after discovering that one of my relatives is memorialised on the monument to those whose remains were unlocated after the second world war.  Over 20,000 names are engraved here.\n\nWorth visiting if you are in Singapore and want to remember the sacrifice of those of many nationalities who fought for the Crown in the Second World War."
+        }
+      ],
+      "description": "Location Information The Commonwealth War Graves Commission's Kranji War Cemetery is 22 kilometres north of the city of Singapore, on the north side of Singapore Island overlooking the Straits of Johore. It is located just to the West of the Singapore-Johore road (Bukit Timah Expressway) on Woodlands Road, just to the south of the crossroads with Turf Club Avenue and Kranji Road. There is a short approach road from the main road. The Cemetery is known locally as Kranji Memorial and one must be sure of the address before boarding a taxi as most taxi drivers do not know the Cemetery. There are also bus stops on the main road facing the Cemetery. The Kranji MRT (train) terminal is a short distance from the Cemetery, approximately 10 to 15 minutes away by foot. A previous visitor has advised us that a small map of the route can be obtained from the MRT ticket office. Visiting Information Kranji War Cemetery is open every day 07:00-18:30. The cemetery is constructed on a hill with the means of access being via three flights of steps, rising over four metres from the road level, which makes wheelchair access to this site impossible.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d386877-Reviews-Kranji_War_Memorial-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "9 Woodlands Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "738656",
+        "address_string": "9 Woodlands Road, Singapore 738656 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.418757",
+      "longitude": "103.75812",
+      "timezone": "Asia/Singapore",
+      "website": "https://www.cwgc.org/find-a-cemetery/cemetery/2004200/kranji-war-cemetery/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d386877-Kranji_War_Memorial-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#20 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "20"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "1006",
+      "review_rating_count": {
+        "1": "2",
+        "2": "6",
+        "3": "78",
+        "4": "248",
+        "5": "672"
+      },
+      "photo_count": "507",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d386877-m66827-Reviews-Kranji_War_Memorial-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Cemeteries",
+              "localized_name": "Cemeteries"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622363",
+          "name": "Sungei Kadut"
+        },
+        {
+          "location_id": "15622517",
+          "name": "Turf Club"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "46"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "375"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "168"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "165"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "134"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "9 Woodlands Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "738656",
+        "address_string": "9 Woodlands Road, Singapore 738656 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Indian National Army (INA) Monument in Singapore": [
+    {
+      "location_id": "3459900",
+      "name": "Indian National Army Monument",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0b/3d/71/61/ina-memorial.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/05/35/e5/da/indian-national-army.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/96/4d/4e/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-p/1b/13/37/94/the-ina-memorial-marker.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-p/1b/13/37/93/the-ina-memorial-marker.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Important milestone ,made in an ordinary way and kept without care.",
+          "text": "Located at Esplanade Park, Singapore,  this monument was built in 1996 on the original site, where it was located, built, and inaugurated by Netaji Shubhas Chandra Bose and subsequently destroyed by Allied Force, post reoccupying of Singapore in 1945.\n   We visited this place. Unfortunately, the plaque is not very popular, and a lot of construction work was going on around this in the park. It took a great effort to locate this. A book shaped structure with inscription of the historical events is inscripted on it. The area is not maintained with the care that should have been given. May be INA being one of the allies  of Japan in WW2 that occupied Songapore and caused severe atrocities on the residents, being the reason."
+        },
+        {
+          "title": "INA",
+          "text": "It's a monument to honour the brave INA soldiers who fought for Indian Freedom,for few they were on wrong side but in the end they had given their life for Indian freedom.Thanks Singapore government for reconstructing this when britishers destroyed it after recapturing of Singapore after war.\nSituated at esplanade park,easy to find, Indians visiting Singapore should must visit this place to pay respect to Netaji and brave soldiers."
+        },
+        {
+          "title": "interesting story but boring attraction",
+          "text": "along esplanade park are numerous points of interest. this is one such attraction. a bit torn about a memorial for the INA especially considering how much the british and australian/nz forces suffered after fall of singapore "
+        },
+        {
+          "title": "Must visit place for every Indian",
+          "text": "Indian National Army memorial is at Esplanade park in Singapore.It is not difficult to locate.The monument speaks about the I N A when Singapore was under the Japanese occupation..."
+        },
+        {
+          "title": "Not much to see",
+          "text": "This site should occupy you for all of 30 seconds as you wander around the Esplanade vicinity. Not too much to see, just a marker where the original monument once briefly stood. "
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d3459900-Reviews-Indian_National_Army_Monument-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 Esplanade Drive Esplanade - Theatres On the Bay",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "038981",
+        "address_string": "1 Esplanade Drive Esplanade - Theatres On the Bay, Singapore 038981 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.28986",
+      "longitude": "103.85592",
+      "timezone": "Asia/Singapore",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d3459900-Indian_National_Army_Monument-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#835 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "835"
+      },
+      "rating": "3.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.0-66827-5.svg",
+      "num_reviews": "19",
+      "review_rating_count": {
+        "1": "2",
+        "2": "3",
+        "3": "8",
+        "4": "4",
+        "5": "2"
+      },
+      "photo_count": "20",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d3459900-m66827-Reviews-Indian_National_Army_Monument-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Monuments & Statues",
+              "localized_name": "Monuments & Statues"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622655",
+          "name": "Marina Centre"
+        },
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "4"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "9"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "1"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "2"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "1 Esplanade Drive Esplanade - Theatres On the Bay",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "038981",
+        "address_string": "1 Esplanade Drive Esplanade - Theatres On the Bay, Singapore 038981 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Reflections at Bukit Chandu: Singapore War Memorial": [
+    {
+      "location_id": "2403126",
+      "name": "Reflections at Bukit Chandu",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/04/80/a8/36/reflections-at-bukit.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1d/e6/fd/77/exterior-of-reflections.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/ad/47/74/filename-06-jpg-thumbnail0.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/23/77/c1/ed/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-p/15/2f/e1/31/photo7jpg.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Highly recommended place to visit in Singapore",
+          "text": "Visited this place today\nHighly recommended\nLocated in a small hill, can walk from Kent ridge park through canopy walk or from hort park.\nLucky to join guided tour by MR Simon. He is super good and knowledgeable. He talk about this museum history and war time with clear explanation.\nThanks a lot."
+        },
+        {
+          "title": "A Country That Remembers Its Heroes",
+          "text": "Reflections at Bukit Chandu is a memorial to what a specific handful of soldiers did during the battle of Singapore.  Which makes it a true memorial to individual men, unlike almost every other war memorial.   I’ve visited battlefields from Pearl Harbor to Passchendaele, and few of them discuss any individual common soldiers.  Gettysburg has lots of monuments honouring the battle’s combatants, but the only ones you’ll see individualized in any way are the generals.   At Verdun, an ossuary holds the bones of at least 130,000 dead, to honour of their “memory,” but no one knows who any of them were or even on which side they fought, so it lets you remember those who cannot be remembered.   By comparison with the 165,000 combatants at Gettysburg or the 700,000 casualties at Verdun, the number of defenders at Bukit Chandu was quite small.  And as for commanding generals, neither Arthur Percival nor Tomoyuki Yamashita was anywhere near that ridge.  \n\nSeveral years ago I reviewed the Menin Gate in Ypers for TripAdvisor and wrote: “The Menin Gate is … thought-provoking … because … [it] allows visitors to delve down to the personal tragedies of individual men and their families.”  This is even truer of Reflections at Bukit Chandu.  At Menin Gate, YOU have to do the delving down; at Reflections at Bukit Chandu, the memorial does it for you.\n\nThe Fall of Singapore was the largest military surrender in British history.  For days Malay troops had been among those fighting Japanese invaders whose plans, equipment, elan, and generalship all were vastly superior.  The museum Reflections at Bukit Chandu does touch on a wide range of subjects related to the disaster, but its focus is on one small part of the overall battle, Bukit Chandu.    \n\nOn the night of January 8th,1942, the Japanese crossed the Strait of Johor and landed on northwestern Singapore Island.  By the 9th, defending Aussie troops, denied reinforcement by Percival, made a forced retreat.  The Japanese, with air support and tanks, neither of which the defenders had, began sweeping southeast toward, among other places, Bukit Chandu.  Their target was the area along Alexandra Road, where the British ammunition, supply depots, oil reserves, and Alexandra military hospital, were concentrated.   The thin red line opposing them was the under-equipped 1st Malaya Infantry Brigade, consisting of a regiment of Lancashiremen and another of Malays.  One defensive position on Bukit Chandu was the Pasir Panjang ridge, where a few dozen Malays commanded by a 27-year-old Malay junior officer, 2nd Lt. Adnan Saidi, took the brunt of the attack.  The Japanese tried a ruse, marching forward troops in formation wearing uniforms taken from a Punjabi unit that had already surrendered during the campaign in Malaya, turbans and all.  Saidi recognized the ruse and the Malays routed the “Punjabi” impostors.  Against overwhelming odds, Saidi and his men held out, despite having little but a mortar and a few machine-guns, and running out of food, ammo, and mortar shells (see Mortar Monument). \n\nAfter two days of stubborn defence on Pasir Panjang, the Japanese finally overran the Malay positions.  Saidi, who was seriously wounded, was hung him upside down from a tree and then repeatedly bayoneted until dead.  The Japanese then went on to massacre the doctors, nurses and wounded patients at Alexandra Hospital.  Other Malay junior officers were told that they had to choose between swearing loyalty to the Japanese, or death.  When the young junior officers refused to do so, they were murdered as well.\n\nThe focus of this museum is on 2nd Lt. Adnan Saidi and his company of men, and beyond that, to the Malaya Regiment—though the museum does look at the large picture of the Fall of Singapore as well.  As the memorial itself says:  “A country that does not remember its heroes, doesn’t deserve to have any.”\n\nNote that rating Reflections at Bukit Chandu is currently undergoing renovations."
+        },
+        {
+          "title": "CLOSED UNTIL 2021",
+          "text": "That's a long time for renovations. But having been before, it probably needs to be closed for that long. Still, Singapore can build 5 new MRT stations in half that time, so you tell me. \nMaybe we will be treated to some new wax heroes in 3 years."
+        },
+        {
+          "title": "Singapore’s unsung war heros",
+          "text": "A must visit place if you are keen on Singapore’s history. Lots of world war two artifacts on display and if you’re a true blue history buff, you may need a couple of hours here. Enjoy!"
+        },
+        {
+          "title": "For history buff",
+          "text": "This little known museum is in a charming colonial bungalow on a hill. Read and watch a video on how the Malay Regiment fought a brave battle against the enemy. There are plagues with the names of those that perished."
+        }
+      ],
+      "description": "Reflections at Bukit Chandu (RBC) is an interpretative centre that commemorates the battle of Pasir Panjang and the men of the Malay Regiment who fought it, as well as the history of Bukit Chandu itself. Housed in a bungalow that is closely connected to the site's history, Reflections at Bukit Chandu uses immersive experiences and contextual artefacts to present a multi-faceted look at Bukit Chandu and Pasir Panjang, while inviting visitors to reflect on our nation’s wartime experience and the brave sacrifice of the soldiers.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2403126-Reviews-Reflections_at_Bukit_Chandu-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "31K Pepys Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "118458",
+        "address_string": "31K Pepys Road, Singapore 118458 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.279337",
+      "longitude": "103.794106",
+      "timezone": "Asia/Singapore",
+      "email": "rbc@nhb.gov.sg",
+      "phone": "+65 6250 6675",
+      "website": "http://bukitchandu.gov.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2403126-Reflections_at_Bukit_Chandu-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#150 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "150"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "89",
+      "review_rating_count": {
+        "1": "0",
+        "2": "2",
+        "3": "4",
+        "4": "42",
+        "5": "41"
+      },
+      "photo_count": "188",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2403126-m66827-Reviews-Reflections_at_Bukit_Chandu-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 2,
+              "time": "0930"
+            },
+            "close": {
+              "day": 2,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0930"
+            },
+            "close": {
+              "day": 3,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0930"
+            },
+            "close": {
+              "day": 4,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0930"
+            },
+            "close": {
+              "day": 5,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0930"
+            },
+            "close": {
+              "day": 6,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0930"
+            },
+            "close": {
+              "day": 7,
+              "time": "1700"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: Closed",
+          "Tuesday: 09:30 - 17:00",
+          "Wednesday: 09:30 - 17:00",
+          "Thursday: 09:30 - 17:00",
+          "Friday: 09:30 - 17:00",
+          "Saturday: 09:30 - 17:00",
+          "Sunday: 09:30 - 17:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Specialty Museums",
+              "localized_name": "Specialty Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622623",
+          "name": "Kent Ridge"
+        },
+        {
+          "location_id": "15622357",
+          "name": "Queenstown"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "2"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "13"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "28"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "11"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "20"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "31K Pepys Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "118458",
+        "address_string": "31K Pepys Road, Singapore 118458 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "The Cenotaph - a Singapore War Memorial Landmark": [
+    {
+      "location_id": "3459938",
+      "name": "Civilian War Memorial",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/2c/b4/c9/73/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/e9/ed/47/civilian-war-memorial.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/47/7a/35/civilian-war-memorial.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/47/7a/0d/civilian-war-memorial.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/47/79/e0/civilian-war-memorial.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Worthwhile",
+          "text": "At the north end of Esplanade Park, this is an effective monument to those civilians who died or were killed during the occupation in WWII.  Its simple but dramatic architecture is a fitting memorial to those many thousands of people.  \n\nIt was also the entry point to a part of history I knew very little about.   It led to a question - what actually happened to Singapore in WWII?    After visiting this monument, I did some research (with the aid of one or two museums in Singapore that document their history),  and now know much more now about what the Singapore  people suffered.   This monument seems like an appropriately sombre but beautiful place to commemorate that."
+        },
+        {
+          "title": "Nice",
+          "text": "Called Four Chopsticks by the locals, the Civilian War Memorial, located at the intersection of Brah Basah Road and Beach Road, is a landmark in the area. Lends grace and aesthetics."
+        },
+        {
+          "title": "A tranquil park in a busy city centre.",
+          "text": "The War Memorial Park is surrounded by iconic buildings such as Raffles Hotel, Raffles City, South Beach etc.  It provides a green and calm respite from the busy city life.  The walkways to the Civilian War Memorial are lined with the Belinjau trees as its conical shape complements the structure of the memorial.  \nAnother feature seen here are the remains of the Stamford Bridge.\nStamford Canal is now a covered culvert lying parallel to Stamford Road.  Long ago, water from this canal would overflow during high tide. Stamford Bridge was first permanent bridge constructed over Stamford Canal in 1956.  Today the canal is covered and turned into a walkway and the bridges were demolished.\nThe remains of Stamford Bridge are two structures which were used to mark its piers. These structures resemble small walls of chiselled stone with a height of about 1 metre.  On each wall is a single black metal plate with the words:\n“1956 Stamford Bridge”."
+        },
+        {
+          "title": "A Solemn Place to Remember the Civilians Who Were Killed During The Japanese Occupation in Singapore ",
+          "text": "This is a solemn place to remember the terrible consequences of war. It is where we pay our respect to the innocent lives that were killed as the result of the war and Japanese Occupation. "
+        },
+        {
+          "title": "Peaceful park",
+          "text": "A memorial for civilians who died during WWII in Singapore. \nPeaceful park with fountains and it is located in the midst of shopping malls, museums and very near Esplanade/City Hall mrt."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d3459938-Reviews-Civilian_War_Memorial-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Bras Basah Road and Beach Road intersection",
+        "street2": "War Memorial Park",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "189561",
+        "address_string": "Bras Basah Road and Beach Road intersection War Memorial Park, Singapore 189561 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.292892",
+      "longitude": "103.85475",
+      "timezone": "Asia/Singapore",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d3459938-Civilian_War_Memorial-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#130 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "130"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "148",
+      "review_rating_count": {
+        "1": "0",
+        "2": "2",
+        "3": "43",
+        "4": "66",
+        "5": "37"
+      },
+      "photo_count": "256",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d3459938-m66827-Reviews-Civilian_War_Memorial-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Monuments & Statues",
+              "localized_name": "Monuments & Statues"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "15622412",
+          "name": "City Hall"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "5"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "45"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "42"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "17"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "17"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "Bras Basah Road and Beach Road intersection",
+        "street2": "War Memorial Park",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "189561",
+        "address_string": "Bras Basah Road and Beach Road intersection War Memorial Park, Singapore 189561 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "The Civilian War Memorial park in Singapore": [
+    {
+      "location_id": "3459938",
+      "name": "Civilian War Memorial",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/2c/b4/c9/73/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/e9/ed/47/civilian-war-memorial.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/47/7a/35/civilian-war-memorial.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/47/7a/0d/civilian-war-memorial.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/47/79/e0/civilian-war-memorial.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Worthwhile",
+          "text": "At the north end of Esplanade Park, this is an effective monument to those civilians who died or were killed during the occupation in WWII.  Its simple but dramatic architecture is a fitting memorial to those many thousands of people.  \n\nIt was also the entry point to a part of history I knew very little about.   It led to a question - what actually happened to Singapore in WWII?    After visiting this monument, I did some research (with the aid of one or two museums in Singapore that document their history),  and now know much more now about what the Singapore  people suffered.   This monument seems like an appropriately sombre but beautiful place to commemorate that."
+        },
+        {
+          "title": "Nice",
+          "text": "Called Four Chopsticks by the locals, the Civilian War Memorial, located at the intersection of Brah Basah Road and Beach Road, is a landmark in the area. Lends grace and aesthetics."
+        },
+        {
+          "title": "A tranquil park in a busy city centre.",
+          "text": "The War Memorial Park is surrounded by iconic buildings such as Raffles Hotel, Raffles City, South Beach etc.  It provides a green and calm respite from the busy city life.  The walkways to the Civilian War Memorial are lined with the Belinjau trees as its conical shape complements the structure of the memorial.  \nAnother feature seen here are the remains of the Stamford Bridge.\nStamford Canal is now a covered culvert lying parallel to Stamford Road.  Long ago, water from this canal would overflow during high tide. Stamford Bridge was first permanent bridge constructed over Stamford Canal in 1956.  Today the canal is covered and turned into a walkway and the bridges were demolished.\nThe remains of Stamford Bridge are two structures which were used to mark its piers. These structures resemble small walls of chiselled stone with a height of about 1 metre.  On each wall is a single black metal plate with the words:\n“1956 Stamford Bridge”."
+        },
+        {
+          "title": "A Solemn Place to Remember the Civilians Who Were Killed During The Japanese Occupation in Singapore ",
+          "text": "This is a solemn place to remember the terrible consequences of war. It is where we pay our respect to the innocent lives that were killed as the result of the war and Japanese Occupation. "
+        },
+        {
+          "title": "Peaceful park",
+          "text": "A memorial for civilians who died during WWII in Singapore. \nPeaceful park with fountains and it is located in the midst of shopping malls, museums and very near Esplanade/City Hall mrt."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d3459938-Reviews-Civilian_War_Memorial-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Bras Basah Road and Beach Road intersection",
+        "street2": "War Memorial Park",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "189561",
+        "address_string": "Bras Basah Road and Beach Road intersection War Memorial Park, Singapore 189561 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.292892",
+      "longitude": "103.85475",
+      "timezone": "Asia/Singapore",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d3459938-Civilian_War_Memorial-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#130 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "130"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "148",
+      "review_rating_count": {
+        "1": "0",
+        "2": "2",
+        "3": "43",
+        "4": "66",
+        "5": "37"
+      },
+      "photo_count": "256",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d3459938-m66827-Reviews-Civilian_War_Memorial-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Monuments & Statues",
+              "localized_name": "Monuments & Statues"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "15622412",
+          "name": "City Hall"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "5"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "45"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "42"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "17"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "17"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "Bras Basah Road and Beach Road intersection",
+        "street2": "War Memorial Park",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "189561",
+        "address_string": "Bras Basah Road and Beach Road intersection War Memorial Park, Singapore 189561 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Sri Veeramakaliamman Temple: Hindu Temple in Singapore": [
+    {
+      "location_id": "317472",
+      "name": "Sri Veeramakaliamman Temple",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/51/54/39/sri-veeramakaliamman.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/5b/e1/e8/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/32/92/3a/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/32/92/39/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/32/92/38/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Inconsiderate and noisy",
+          "text": "I am a resident who lives nearby. Everyday I have to endure their constant loud repetitive drumming and trumpeting, sometimes late into the night and early in the morning. \n\nI suggest the temple to double the height of its wall next to the courtyard to keep the pooja \"music\" within its compound. It's a living nightmare to stay next to this temple. \n\nWhat kind of God permits them to cause others to suffer through constant extreme loud noises. There are residents who are sick and need proper rest at home. I hope the temple read this review and look at the sin they are committing upon others."
+        },
+        {
+          "title": "It is a temple",
+          "text": "I was staying at the Hilton Garden Inn which is close to this temple, so I decided to stop in to take a look. I was lucky enough to be there during prayer. But the temple as such is nothing to write home about or perhaps it is simply so that I am too ignorant to appreciate it."
+        },
+        {
+          "title": "Are we serious?",
+          "text": "Honestly, having visited numerous temples in my many trips to (different areas) of India, this one really struck me as one of the least impressive and somewhat tacky."
+        },
+        {
+          "title": "Divine place",
+          "text": "Visited this temple in October 2024 to seek the divine blessings of Veeramahakaliamman. The temple situated at the heart of Serangoon Road is easily accessible with Archakas (Priests) performing the rituals in traditional Hindu way."
+        },
+        {
+          "title": "The Temple is Open to All",
+          "text": "To visit the temple full of worshippers was an unforgettable privilege. The sights and sounds will live long in the memory. The artistry of the temple images was life like yet mystical."
+        }
+      ],
+      "description": "Built in 1855 by Tamil labourers, the temple has a South Indian architectural style. The gopuram or tower, a common element in South Indian temple architecture, was built at a height so that it can be seen from a distance.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d317472-Reviews-Sri_Veeramakaliamman_Temple-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "141 Serangoon Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "218042",
+        "address_string": "141 Serangoon Road, Singapore 218042 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.30805",
+      "longitude": "103.85216",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6295 4538",
+      "website": "http://www.sriveeramakaliamman.com",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d317472-Sri_Veeramakaliamman_Temple-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#69 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "69"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "567",
+      "review_rating_count": {
+        "1": "6",
+        "2": "6",
+        "3": "84",
+        "4": "287",
+        "5": "185"
+      },
+      "photo_count": "959",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d317472-m66827-Reviews-Sri_Veeramakaliamman_Temple-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0500"
+            },
+            "close": {
+              "day": 1,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0500"
+            },
+            "close": {
+              "day": 2,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0500"
+            },
+            "close": {
+              "day": 3,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0500"
+            },
+            "close": {
+              "day": 4,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0500"
+            },
+            "close": {
+              "day": 5,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0500"
+            },
+            "close": {
+              "day": 6,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0500"
+            },
+            "close": {
+              "day": 7,
+              "time": "2100"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 05:00 - 21:00",
+          "Tuesday: 05:00 - 21:00",
+          "Wednesday: 05:00 - 21:00",
+          "Thursday: 05:00 - 21:00",
+          "Friday: 05:00 - 21:00",
+          "Saturday: 05:00 - 21:00",
+          "Sunday: 05:00 - 21:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Sacred & Religious Sites",
+              "localized_name": "Sacred & Religious Sites"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "7291621",
+          "name": "Little India"
+        },
+        {
+          "location_id": "15622484",
+          "name": "Farrer Park"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "8"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "172"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "108"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "87"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "83"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "141 Serangoon Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "218042",
+        "address_string": "141 Serangoon Road, Singapore 218042 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Maghain Aboth Synagogue": [
+    {
+      "location_id": "2341786",
+      "name": "Maghain Aboth",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0f/84/54/e4/the-synagogue.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/1d/3e/7e/maghain-aboth-synagogue.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0a/38/7a/53/20160205-073436-largejpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/bd/90/fa/jewish-heritage-tour.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/bd/90/f9/jewish-heritage-tour.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Jewish community of Singapore - great place to daven and eat on Shabbos",
+          "text": "I spent a few days in Singapore including a Shabbat and my son and I attended morning minyan on a couple of weekdays as well  as shul on Shabbat. The favoring was pleasant and the people friendly. There were a fair amount of Israelis there in addition to people from other countries. The main sanctuary is beautiful and worth seeing!"
+        },
+        {
+          "title": "Lovely shul",
+          "text": "The shul is certainly beautiful and the davening interesting (Sephardi) but I was surprised no one came up to say hello when we stuck out and it is a small community. I guess they aren’t so interested in travellers who are there for one week only. People who are there longer seem to be very happy"
+        },
+        {
+          "title": "Waterloo street with a Synagogue, Church, Hindu temple and a Buddhist-Taoist temple.",
+          "text": "The first synagogue was built in a shophouse at Synagogue Street beside the OCBC centre.  Mr Manasseh Meyer was instrumental in building Maghain Aboth Synagogue to accommodate the growing number of Jews who began moving to the Dhoby Ghaut and Bras Basah areas.  This is the oldest surviving synagogue in South-East Asia.  It is presently a two-storey building built in the Neo-Classical style and its facade bears three stars of David.  A famous visitor of Mr Meyer was scientist Albert Einstein who visited the Jewish community here in 1922.  There is a kosher minmart and a kosher restaurant called Awafi in the Jacob Ballas building beside it in the same compound."
+        },
+        {
+          "title": "A warm Home away from home",
+          "text": "I just read a review by POODW who gave a review not worthy of bothering to post.He stated that it was the most unfriendly synagogue he had ever been to\nWhere did this man wake up. He must have gone there looking for a pat on the back because he attended.\nWell, we have been there twice in the last few years, and each time I was greeted by somebody . And as a tourist, looking for a sense of home away from home, I got what I wanted, a Saturday service. The warm handshakes later , the greeting from others who are regular as well as regular seasonal, was more than welcoming, and I am still in contact with them years later. This was all a bonus and made for a lovely extended morning at least until 2 pm. The best part. Was this time my hotel was actually just behind the building so I did not require transport.\nThe rabbi, is a very genuine fellow, warm and welcoming, and the guest speaker who happened to be there was interesting and informative. Many people at the place were tourists and everybody was interested in each other.\nA great place, and I / we look forward to coming back."
+        },
+        {
+          "title": "If you are Jewish, by all means, go on Saturday morning....",
+          "text": "I have been visiting since 1979. Tremendous improvements. Now air-conditioned and not falling in. Also as adjacent school, social building with dining hall and chapel, community rooms. They are Sephardim and Orthodox. So they don't really care about non-Jews. Jews are welcomed but it's not like in the West. Women may come to services but must sit upstairs in the gallery. \n\nNo page announcements. Occasionally, someone on the pulpit will announce a prayer, as well as Kaddish. If you are Jewish and familiar with the service, you will be fine. If not, forget it. Afterwards, you will be invited to the Kiddush and perhaps a full lunch, on weeks they have it. Free. Often there is a separate service for Ashkenazim in the Ballas building chapel. Again, Orthodox; women sit apart. If you are called to the Torah with your mother's name as well as your father's, forget it. But any Jewish male will be given an honor.\n\nAlso: don't forget to go into the Ark after the service to see all the Tiorah scrolls, in either wood or silver covers, from the congregation as welll as from vanished Jewish communities in Penang, Jakarta. Maybe 20 there, as well as the scrolls used by the congregation.\n\nIf you are an ex-pat, likely someone may invite you home for a meal or for a holiday, say, if you work in KL or Jakarta and come to Singapore for business or just to find a synagogue. \n\nNumbers have increased past 15 years in part because of growing ex-pat community, largely from U.S. and Canada. Even an Israeli or two."
+        }
+      ],
+      "description": "Learn about Singapore’s early Jewish settlers at the Maghain Aboth Synagogue. Constructed in 1878, the Maghain Aboth, which means Shield of Our Fathers, is the oldest Jewis building in Southeast Asia.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2341786-Reviews-Maghain_Aboth-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "24 Waterloo St.",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "187950",
+        "address_string": "24 Waterloo St., Singapore 187950 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.29827",
+      "longitude": "103.8506",
+      "timezone": "Asia/Singapore",
+      "email": "enquiry@jwb.org.sg",
+      "phone": "+65 6337 2189",
+      "website": "http://www.yoursingapore.com/content/traveller/en/browse/see-and-do/culture-and-heritage/places-of-worship/maghain-aboth-synagogue.html?TAHotelCode=110",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2341786-Maghain_Aboth-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#501 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "501"
+      },
+      "rating": "3.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.5-66827-5.svg",
+      "num_reviews": "20",
+      "review_rating_count": {
+        "1": "3",
+        "2": "2",
+        "3": "6",
+        "4": "4",
+        "5": "5"
+      },
+      "photo_count": "24",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2341786-m66827-Reviews-Maghain_Aboth-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Sacred & Religious Sites",
+              "localized_name": "Sacred & Religious Sites"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622525",
+          "name": "Victoria"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "2"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "5"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "10"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "2"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "0"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "24 Waterloo St.",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "187950",
+        "address_string": "24 Waterloo St., Singapore 187950 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Old Supreme Court Singapore": [
+    {
+      "location_id": "317473",
+      "name": "Old Supreme Court Building",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/59/87/06/supreme-court.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/58/88/aa/supreme-court.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/a9/26/8e/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/a9/26/8d/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/a9/26/91/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "history meets cutting edge art ",
+          "text": "Gorgeously preserved stunning architecture and a unique insight into Singapore history, plus endless arts events "
+        },
+        {
+          "title": "Look out for the Time Capsule!",
+          "text": "Definitely worth a visit if you are in Singapore. Located right in the smack of all the attractions and tourist places. This place is bound to take you back in time to witness our Proclamation of Independence and, our history and our fight for freedom. There are lots of artefacts and displays dating back to our rise before and after the Japanese invasion. A must visit!"
+        },
+        {
+          "title": "Architecture",
+          "text": "A brilliant example of the classical British architecture that can be found in the colonial district."
+        },
+        {
+          "title": "Cool building",
+          "text": "This is a very cool old building.  It looks very british to me.  It's very cool that it is located in a far east locale.  Very nice."
+        },
+        {
+          "title": "Nice old building ",
+          "text": "One of the old British government buildings, you should try to pass by to see this building during your sightseeing in Singapore."
+        }
+      ],
+      "description": "Supreme Court",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d317473-Reviews-Old_Supreme_Court_Building-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 St. Andrew's Road National Gallery Singapore",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "178957",
+        "address_string": "1 St. Andrew's Road National Gallery Singapore, Singapore 178957 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.290399",
+      "longitude": "103.85081",
+      "timezone": "Asia/Singapore",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d317473-Old_Supreme_Court_Building-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#178 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "178"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "78",
+      "review_rating_count": {
+        "1": "0",
+        "2": "0",
+        "3": "15",
+        "4": "39",
+        "5": "24"
+      },
+      "photo_count": "66",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d317473-m66827-Reviews-Old_Supreme_Court_Building-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Government Buildings",
+              "localized_name": "Government Buildings"
+            },
+            {
+              "name": "Architectural Buildings",
+              "localized_name": "Architectural Buildings"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622412",
+          "name": "City Hall"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "1"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "16"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "21"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "9"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "9"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "1 St. Andrew's Road National Gallery Singapore",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "178957",
+        "address_string": "1 St. Andrew's Road National Gallery Singapore, Singapore 178957 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "SIT Flats Singapore": [
+    {
+      "location_id": "4283466",
+      "name": "Singapore River",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/03/22/98/82/singapore-river.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/03/22/97/6b/singapore-river.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/03/22/99/5b/singapore-river.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/03/22/99/44/singapore-river.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/03/22/98/fc/singapore-river.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Amazing place for many attractions",
+          "text": "On our 3 days trip to Singapore this time, we never wasted a chance to walk around this river, right from Four Points to Durian building both in broad daylight and colorful nights. The facility is amazing clean & tidy, surrounded by cafes, restaurants, sky scrappers, clark quay, bungee jumping, boat rides etc. plenty of options, safe and very secure. Must try yourself"
+        },
+        {
+          "title": "Good",
+          "text": "One of a few interesting things to do in Singapore. You'll see Singapore nightlife on the boat. The country is not big and the trip lasts for around 30-40'."
+        },
+        {
+          "title": "Great Way to see the Sights",
+          "text": "Cooler on the river. Interesting and scenic. Helpful commentary. Useful and fun. Recommended, especially if pushed for time."
+        },
+        {
+          "title": "Love the night light reflections off the peaceful, ever-flowing water",
+          "text": "The Singapore River is the flowing lifeblood of this vibrant city. Having a wall writer family member, I took a particular interest in the beautiful murals on the walls of the river underpasses."
+        },
+        {
+          "title": "Spectacular transformation over the years.",
+          "text": "Lovely area to visit and stroll the boardwalks/promenades, visit a restaurant, marvel at the high-rise buildings and their architecture or enjoy a river cruise and listen to the description of the various historical and contemporary landmarks as you pass by. So much different to my first visit in 1976 and my trip on the river in a bumboat. Back then it was dirty, polluted with waste and the Government were initiating a program of resettlement and cleanup in order to transform the area.  The transition has been spectacular but the bustle of those early times is missing."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d4283466-Reviews-Singapore_River-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Boat, Clarke, Robertson Quays",
+        "city": "Singapore",
+        "country": "Singapore",
+        "address_string": "Boat, Clarke, Robertson Quays, Singapore Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.28991",
+      "longitude": "103.83945",
+      "timezone": "Asia/Singapore",
+      "email": "team@singapore-river.com",
+      "phone": "+65 6336 6111",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d4283466-Singapore_River-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#34 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "34"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "2178",
+      "review_rating_count": {
+        "1": "7",
+        "2": "10",
+        "3": "201",
+        "4": "893",
+        "5": "1067"
+      },
+      "photo_count": "1553",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d4283466-m66827-Reviews-Singapore_River-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Bodies of Water",
+              "localized_name": "Bodies of Water"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622524",
+          "name": "Robertson Quay"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291610",
+          "name": "The Quays"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "108"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "700"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "237"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "419"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "295"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "Boat, Clarke, Robertson Quays",
+        "city": "Singapore",
+        "country": "Singapore",
+        "address_string": "Boat, Clarke, Robertson Quays, Singapore Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Lau Pa Sat Singapore": [
+    {
+      "location_id": "386879",
+      "name": "Food Folks @ Lau Pa Sat",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/2c/2b/f3/be/food-folks-lau-pa-sat.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2a/6d/a9/0c/food-folks-lau-pa-sat.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2a/6d/a9/75/retail-zone-grab-and.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2a/6d/a9/51/retail-zone-world-favourites.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2a/6d/a9/35/retail-zone-love-healthy.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Always worth a visit",
+          "text": "Very large hawker centre that needs to be tried. Multiple choices of food and open seating areas. Bit more expensive than normal hawkers but is very central and a popular attraction"
+        },
+        {
+          "title": "Worth a visit",
+          "text": "Visited for lunch with our 3 young children. The food is lovely and the area is quite clean.it was quite humid but the fans work hard to cool down!\nLots of food choices"
+        },
+        {
+          "title": "Well worth a visit",
+          "text": "Worth a visit. It is very chaotic and don’t forget to bring your own wipes/tissues. But great choice of food and you can choose what you want to eat or drink from a variety of vendors. All serving amazing food. Very cheap and nice atmosphere"
+        },
+        {
+          "title": "Great spot for an authentic snack",
+          "text": "Great place to try authentic satay with a wide choice of accompaniments in a great location in the middle of the city. Bit touristy but super tasty."
+        },
+        {
+          "title": "YouTube Influencer recommendation",
+          "text": "Saw this food market on YouTube and also a friend recommended it  ( as top tourist one )so wanted to try it as I’d been to Newton Circus 30 years earlier in my travels… We arrive from the tube station further down the road and could smell the satay stands which enticed us in the right direction that evening…\nOutside there was a huge picnic table area with at least 10 to 15 satay style stands with fresh prawns and meat, inside was a rabbit warren of food stalls with everything and anything you could imagine not to mention stalls serving alcohol and fresh fruit drinks and smoothies…\nIt was first class although the stand we went to for prawns and satay there was a 30 minute wait as it had stickers on the front from Tripadvisor and other Sites… So possibly in hide-site we should of tried another faster place as they all serve same and similar prices…\nOverall a great place to eat, we went back a 2nd time at approximately 23:30 and all but 2 closed which we thought strange… Anyway had a nice dim sim meal 2nd time…"
+        }
+      ],
+      "description": "Food Folks @ Lau Pa Sat is Singapore’s first locally-focused “Everything Food\" concept that blends food retail products and F&B establishments within a gazetted monument. The purpose-driven retail concept features more than 70% local food brands, and provides a launch pad to help local food retail and F&B brands grow and establish their brand presence. The space is also thoughtfully designed to inspire the community with positive and meaningful experiences around the love of all things food. #SupportSG",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d386879-Reviews-Food_Folks_Lau_Pa_Sat-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "18 Raffles Quay",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "048582",
+        "address_string": "18 Raffles Quay, Singapore 048582 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.280437",
+      "longitude": "103.85053",
+      "timezone": "Asia/Singapore",
+      "email": "hello@foodfolks.sg",
+      "phone": "+65 6220 2138",
+      "website": "http://www.laupasat.sg/food-folks/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d386879-Food_Folks_Lau_Pa_Sat-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#65 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "65"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "1581",
+      "review_rating_count": {
+        "1": "34",
+        "2": "63",
+        "3": "264",
+        "4": "666",
+        "5": "554"
+      },
+      "photo_count": "778",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d386879-m66827-Reviews-Food_Folks_Lau_Pa_Sat-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "2200"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 22:00",
+          "Tuesday: 10:00 - 22:00",
+          "Wednesday: 10:00 - 22:00",
+          "Thursday: 10:00 - 22:00",
+          "Friday: 10:00 - 22:00",
+          "Saturday: 10:00 - 22:00",
+          "Sunday: 10:00 - 22:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "shopping",
+          "localized_name": "Shopping"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Shopping",
+          "localized_name": "Shopping",
+          "categories": [
+            {
+              "name": "Flea & Street Markets",
+              "localized_name": "Flea & Street Markets"
+            }
+          ]
+        },
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Historic Sites",
+              "localized_name": "Historic Sites"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622415",
+          "name": "Cecil"
+        },
+        {
+          "location_id": "15622676",
+          "name": "Central Business District"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "75"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "401"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "121"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "262"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "293"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "18 Raffles Quay",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "048582",
+        "address_string": "18 Raffles Quay, Singapore 048582 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Malay Heritage Centre, Singapore": [
+    {
+      "location_id": "1371240",
+      "name": "Malay Heritage Centre",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/03/70/13/4a/the-former-palace-which.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/2b/6f/2a/malay-heritage-centre.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/9e/8c/e9/mhc-night-facade.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/2c/95/d5/malay-heritage-centre.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/2c/95/cf/malay-heritage-centre.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Favorite Place",
+          "text": "Wonderful visit! The staffs are friendly. Learnt a lot about Malay heritage. The exhibition are interesting and the gifts nice to buy."
+        },
+        {
+          "title": "Historical, Heritage and Cultural facts",
+          "text": "Interesting and educational place to spend with family, understanding the historical facts and cultural background. Our family, 2A, 2C, age 13 & 7 thoroughly enjoyed our visit. We also learnt more about Gems and other precious stones and especially the 77 Carats diamond! There is also has an interesting plot of small land with various plants and trees within the Malay Heritage Center.\n\nAlso we found out that my husband lived in the same road as Mr Omar Ahmad! It was during the mid 60s to early 80s when he was living with his grandparents!! What a nice finding! I am quite sure his late grandparents might even know Mr Omar Ahmad!\n\nHighly recommended to family outings."
+        },
+        {
+          "title": "Unsure they know how their own pricing system works ",
+          "text": "Well I haven’t seen the Centre yet and I hope it doesn’t disappoint but being refused a family ticket as there were 4 of us (2 adults and 2 children) and a family ticket (cheaper) is for 5 was a poor first experience!"
+        },
+        {
+          "title": "Interesting history of the Malay community",
+          "text": "We came back here for another visit in late March, before everything closed down for the lockdown period. Entrance for PRs and citizens is free, so it's a good option for keeping the kids entertained. A few interesting exhibits inside and a good overview of local history of the Malay community."
+        },
+        {
+          "title": "Easily worth a couple of hours!",
+          "text": "Situated in Singapore's heritage district of Kampong Glam and right next to the Sultan Mosque, the Malay Heritage Centre provides excellent cultural insights into the Malay community in Singapore. The visit starts at the upper level, followed by the lower level and two external outhouses, housing permanent galleries. They showcase stories and artifacts from both Singapore's national collection as well as contributions from the local community. It is a reflection of Kampong Glam's historical significance as well as the contribution of the local Malay society. The structure was once of traditional timber built on stilts, which has been thoroughly renovated over time. It is open from Tuesday to Sunday, 10:00am to 6:00pm, with free admission for all Singaporeans & Permanent Residents. A couple of hours can be easily spent here."
+        }
+      ],
+      "description": "Officially re-opened by Prime Minister Lee Hsien Loong in September 2012, the Malay Heritage Centre (MHC) showcases the history, culture and contributions of the Malay community within the context of Singapore's history and multi-cultural society. MHC's permanent galleries focus on the history of Kampong Gelam and showcase an interesting collecting of artefacts from the National Collection and the Malay community. Through its exhibitions and programmes, the centre aspires to be a vibrant destination of historical and cultural significance for both Singaporeans and international visitors. MHC is under the management of the National Heritage Board in partnership with The Malay Heritage Foundation.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d1371240-Reviews-Malay_Heritage_Centre-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "85 Sultan Gate",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "198501",
+        "address_string": "85 Sultan Gate, Singapore 198501 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.302485",
+      "longitude": "103.85988",
+      "timezone": "Asia/Singapore",
+      "email": "NHB_MHC@nhb.gov.sg",
+      "phone": "+65 6391 0450",
+      "website": "http://www.malayheritage.org.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d1371240-Malay_Heritage_Centre-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#147 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "147"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "171",
+      "review_rating_count": {
+        "1": "4",
+        "2": "2",
+        "3": "49",
+        "4": "68",
+        "5": "48"
+      },
+      "photo_count": "250",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d1371240-m66827-Reviews-Malay_Heritage_Centre-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1800"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: Closed",
+          "Tuesday: 10:00 - 18:00",
+          "Wednesday: 10:00 - 18:00",
+          "Thursday: 10:00 - 18:00",
+          "Friday: 10:00 - 18:00",
+          "Saturday: 10:00 - 18:00",
+          "Sunday: 10:00 - 18:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "History Museums",
+              "localized_name": "History Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291617",
+          "name": "Kampong Glam"
+        },
+        {
+          "location_id": "15622680",
+          "name": "Arab Street"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "5"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "41"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "38"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "27"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "27"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "85 Sultan Gate",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "198501",
+        "address_string": "85 Sultan Gate, Singapore 198501 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Peranakan Museum Singapore: History & Culture": [
+    {
+      "location_id": "1491151",
+      "name": "Peranakan Museum",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/14/7a/a6/view-from-across-the.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/e4/29/91/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/e4/29/90/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/bf/60/d5/peranakan-museum.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/42/f6/5f/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Terrible",
+          "text": "Overrun with school children. Don’t come here unless you want to pay tourist prices to have your experience completely ruined by around 100 noisy school children who completely take over the space. My experience was completely ruined by about 5 separate groups of loud school children, who took over every room I went to! Why should I pay the tourist entrance fee which is way more expensive and have these children, who paid nothing to enter, completely ruin the whole experience?! Staff couldn’t care less and allow children to run wild throughout the museum! Would never return here! And would advise to check before paying the entrance fee to see if school trips are booked in that day. The venue is small and should not be allowing so many groups of school children to enter at the same time! Not fair on paying customers!"
+        },
+        {
+          "title": "Superb Museum, Not to be Missed",
+          "text": "Lovely small museum in a traditional house. The focus is on the Parakanan culture and people, essentially the diversity of people resulting from the centuries of trade. Has an excellent batik exhibit. Try to find a restaurant that specializes in that style of food."
+        },
+        {
+          "title": "Fascinating culture",
+          "text": "This was an interesting and thorough museum explaining and illustrating Peranakan life , which to be honest I had no prior knowledge of. Its well worth going to, very easy to find on Armenian street, the museum has clear descriptions and good displays. I particularly enjoyed the betel nut paraphenalia and the batik exhibition. In general the textiles were very much the star here although there was some very nice jewellery also. It is a fascinating culture and the museum is well worth a look if you are in Singapore."
+        },
+        {
+          "title": "Stunning examples of Peranaken art, furniture, clothing, porcelain",
+          "text": "This is a really special museum- I think the best in Singapore. Went to see the Nonya Batik exhibition which was wonderful. 3 generations of women who produced the most beautiful artwork. Explanations and videos were great. The rest of the museum is a feast for the eyes too. Stunning Peranaken furniture. The clothing exhibition is really worth a look too. As is the porcelain. Loved it."
+        },
+        {
+          "title": "Stories of the Peranakan people",
+          "text": "This is a very interesting museum that is housed in the former Tao Nan Chinese School which was built in 1912. Beautiful building in the Neoclassical architecture style with the exhibits showcased on three floors. Very well curated and showcasing furniture, jewelry, clothing, textiles, batik fabrics and historical photographs, all relics of a snapshot of history. Wish we had been aware that free tours are conducted, worthwhile checking in advance of a visit."
+        }
+      ],
+      "description": "The Peranakan Museum explores the culture of Peranakan communities in Southeast Asia. Installed in the former Tao Nan Chinese School, built in 1912, this intimate museum possesses one of the finest and most comprehensive collections of Peranakan objects. Galleries on three floors illustrate the cultural traditions and the distinctive visual arts of the Peranakans. The Peranakan Museum provides a stimulating and educational experience for all, while representing the living culture of the Peranakan community in the region. The museum is a component of the Asian Civilisations Museum, operating under the National Heritage Board.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d1491151-Reviews-Peranakan_Museum-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "39 Armenian Street",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179941",
+        "address_string": "39 Armenian Street, Singapore 179941 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.29421",
+      "longitude": "103.84895",
+      "timezone": "Asia/Singapore",
+      "email": "nhb_pm_vs@nhb.gov.sg",
+      "phone": "+65 6332 7591",
+      "website": "http://peranakanmuseum.org.sg/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d1491151-Peranakan_Museum-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#42 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "42"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "1260",
+      "review_rating_count": {
+        "1": "4",
+        "2": "18",
+        "3": "120",
+        "4": "499",
+        "5": "619"
+      },
+      "photo_count": "916",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d1491151-m66827-Reviews-Peranakan_Museum-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 19:00",
+          "Tuesday: 10:00 - 19:00",
+          "Wednesday: 10:00 - 19:00",
+          "Thursday: 10:00 - 19:00",
+          "Friday: 10:00 - 21:00",
+          "Saturday: 10:00 - 19:00",
+          "Sunday: 10:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Specialty Museums",
+              "localized_name": "Specialty Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622372",
+          "name": "Museum"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        },
+        {
+          "location_id": "15622424",
+          "name": "Bras Basah"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "45"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "321"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "277"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "216"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "217"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "39 Armenian Street",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179941",
+        "address_string": "39 Armenian Street, Singapore 179941 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Raffles Singapore": [
+    {
+      "location_id": "2139569",
+      "name": "Raffles City",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0f/47/d9/e3/photo0jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/41/2f/0b/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/41/2f/0a/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/41/2f/09/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/41/2f/08/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Hundred Grains Restaurant",
+          "text": "A group of us met at Raffles City for lunch. A couple of friends got there early so they decided to explore the place. In the past, we had dined in the basement.  There  isn’t much choice there.  This time they turned into City Link and saw the Hundred Grains Restaurant.  It looked interesting so everyone agreed to dine there.  It’s buffet style.  We got a tray and filled it with food. Then we went to the cashier to get it weighed. It costs $3.60 per 100gm.  We can take as much or as little as we want.  Brown rice, white rice and porridge are free. So are the drinks and fruit.  It’s a great idea because there was no waste.  Everyone was bringing their leftovers home.  The MRT station is City Hall and City Link is on the right, after one exits the station. It’s clearly marked. I enjoyed the food and wouldn’t hesitate to return again."
+        },
+        {
+          "title": "Aging mall",
+          "text": "The basement food and supermarket level is the most crowded. The upper floors are quiet but you can get restaurants, optical shops etc. there"
+        },
+        {
+          "title": "Raffle city",
+          "text": "Only exchanger I found here\n Nice and tidy place. Nearby the swiss hotel stamford. Many shops you will find. Enjoy the ride"
+        },
+        {
+          "title": "Busy mal,",
+          "text": "Raffles City's is connected to the City Hall MRT station. It's very crowded with some good shops like the chocolate shop. There is a large market in the basement. Since my hotel wasn't nearby, and the weather was so hot, I couldn't buy any food to take away. Good for shopping."
+        },
+        {
+          "title": "Confusing toilet signs that the fact that I have to go inside the exit sign just to get to the toilet",
+          "text": "The signs are so confusing that when I go find the toilet sign I thought the toilet was there that the fact that I had to get through the whole exit sign and we have to go in the exit sign just to find the toilet"
+        }
+      ],
+      "description": "\"Situated in the Civic District close to historic and tourist sites, Raffles City Shopping Centre is a haven for consumers looking for luxury items. Built on the site of a former school (Raffles Institution), Raffles City is downtown shopping at its finest. The mall has a number of luxury and designer stores such as Omega, Thomas Sabo, Cortefiel and Tommy Hilfiger, among others. Here, you’ll also find big department stores like Marks & Spencer and Robinsons, and fashion chains like Topshop, River Island and Skyla. In fact, Raffles City covers most shopping bases with fashion, books, music, sports, toys, eyewear and beauty all available above the City Hall MRT station, which makes getting here all the more convenient. \"",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2139569-Reviews-Raffles_City-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "252 North Bridge Rd",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179103",
+        "address_string": "252 North Bridge Rd, Singapore 179103 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.294054",
+      "longitude": "103.85316",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6318 0238",
+      "website": "http://www.rafflescity.com.sg/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2139569-Raffles_City-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#73 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "73"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "540",
+      "review_rating_count": {
+        "1": "2",
+        "2": "4",
+        "3": "91",
+        "4": "281",
+        "5": "162"
+      },
+      "photo_count": "431",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2139569-m66827-Reviews-Raffles_City-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "2200"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 22:00",
+          "Tuesday: 10:00 - 22:00",
+          "Wednesday: 10:00 - 22:00",
+          "Thursday: 10:00 - 22:00",
+          "Friday: 10:00 - 22:00",
+          "Saturday: 10:00 - 22:00",
+          "Sunday: 10:00 - 22:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "shopping",
+          "localized_name": "Shopping"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Shopping",
+          "localized_name": "Shopping",
+          "categories": [
+            {
+              "name": "Shopping Malls",
+              "localized_name": "Shopping Malls"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622412",
+          "name": "City Hall"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "25"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "181"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "93"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "84"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "55"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "252 North Bridge Rd",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179103",
+        "address_string": "252 North Bridge Rd, Singapore 179103 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Gillman Barracks â€“ YourSingapore": [
+    {
+      "location_id": "4355460",
+      "name": "Gillman Barracks",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/ce/e2/ff/20180428-085917-largejpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/06/a7/a5/06/gillman-barracks.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/06/a7/a5/66/gillman-barracks.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/06/a7/a5/62/gillman-barracks.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/06/a7/a5/49/gillman-barracks.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "The Academy of Singapore Teachers",
+          "text": "The Academy of Singapore Teachers is just beside Gillman Barracks. I came here to use the co-work office and found it to be conducive.\n\nLibrary, pantry, track field and office all in one. When hungry, one can just buy something to bite  from the pantry which is co-located within the library. \n\nTired looking at the computer screen, one can take also take a breather and just browse at the books in the library or go for a jog or stroll at the track field just located outside the office.\n\nI walked over here from my house but one can also drive in. Free parking in the compound for those who have access to the co-work office.\n\nNice and immersive."
+        },
+        {
+          "title": "Disappointing",
+          "text": "I had such high hopes for this place after seeing a mural online by Felipe Pantone. The area itself is nice, lush and interesting. When we went there was only 2 buildings open and only one food venue. The exhibitions were minimal and really not worth the effort. \nThe Felipe Pantone had been painted over and there was just a gapping lack of atmosphere. The potential is there but it just didn't deliver."
+        },
+        {
+          "title": "Casual and Hippie Place to eat and chill",
+          "text": "Hippie diner cafe/restaurant with the owner's motorbikes and guitars on display gives it an 80s charm to the ambience.\nFood is great especially rock and roll salmon and mamma porkchop which cannot go wrong on any days."
+        },
+        {
+          "title": "Free Galleries",
+          "text": "- Amazing artwork in different blocks within Gillman Barracks\n- Approachable staff\n- Best to go on weekdays to avoid crowds"
+        },
+        {
+          "title": "not recommended",
+          "text": "many places closed, neglected or with an unfriendly vibe. Shangart was the best - just. Hard to see why many people would want to visit or enjoy it if they did. Sad really  - the site has potential"
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d4355460-Reviews-Gillman_Barracks-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "9 Lock Road Gillman Barracks",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "108937",
+        "address_string": "9 Lock Road Gillman Barracks, Singapore 108937 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.27831",
+      "longitude": "103.80436",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6694 4077",
+      "website": "http://www.gillmanbarracks.com",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d4355460-Gillman_Barracks-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#250 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "250"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "62",
+      "review_rating_count": {
+        "1": "3",
+        "2": "2",
+        "3": "9",
+        "4": "33",
+        "5": "15"
+      },
+      "photo_count": "118",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d4355460-m66827-Reviews-Gillman_Barracks-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 2,
+              "time": "1200"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1200"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1200"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1200"
+            },
+            "close": {
+              "day": 5,
+              "time": "2115"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1200"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1200"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: Closed",
+          "Tuesday: 12:00 - 19:00",
+          "Wednesday: 12:00 - 19:00",
+          "Thursday: 12:00 - 19:00",
+          "Friday: 12:00 - 21:15",
+          "Saturday: 12:00 - 19:00",
+          "Sunday: 12:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622606",
+          "name": "Telok Blangah Drive"
+        },
+        {
+          "location_id": "15622331",
+          "name": "Bukit Merah"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "2"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "19"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "15"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "9"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "9"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "9 Lock Road Gillman Barracks",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "108937",
+        "address_string": "9 Lock Road Gillman Barracks, Singapore 108937 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "ArtScience Museum Singapore": [
+    {
+      "location_id": "2138895",
+      "name": "ArtScience Museum at Marina Bay Sands",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/0a/88/c8/artscience-museum.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/0d/46/41/oculus-in-artscience.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/0d/46/40/artscience-museum.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/0d/46/3f/future-world-where-art.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/0a/88/cb/artscience-museum.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "It’s nice to look at",
+          "text": "The building is beautiful but that’s all it has going for it. Save your money and go a Hawker centre if you want something that is interesting."
+        },
+        {
+          "title": "Feel misled",
+          "text": "When we bought our tickets we were told to do the ground floor before going upstairs. What we weren't told was that the galeries on the upper floors were actually closed so only the lower floor had any displays which made the museum very poor value indeed. What was there was very good and very interactive but not worth the admission price. Do check what you are getting for your money before you go. It's been rated 3 because of the poor value."
+        },
+        {
+          "title": "No science just lights for the kids",
+          "text": "As a scientist I can honestly say there is nothing scientific in the museum. The whole thing is a projection light show which is mainly for kids - very disappointing and certainly not value for money."
+        },
+        {
+          "title": "Not worth it for the price, but pleasant",
+          "text": "I wouldn’t spend $40 SGD on the experience, but there was some nice stuff to see. Probably more worthwhile for kids, who would love the little tunnels and interactive drawing elements"
+        },
+        {
+          "title": "Studio Ghilbi ",
+          "text": "Went for the Studio Ghilbi exhibition mainly for teen son. We all enjoyed it a lot. Exhibits were stunning and very creative. Prices in the gift shop however were exorbitant "
+        }
+      ],
+      "description": "ArtScience Museum is an iconic cultural landmark in Singapore and the cultural component of Marina Bay Sands. With 21 gallery spaces, ArtScience Museum has held large-scale exhibitions by some of the world’s major artists, including Leonardo da Vinci, M.C. Escher, Salvador Dalí, Andy Warhol and Vincent Van Gogh since opening in February 2011. In addition, we have presented significant exhibitions that explore aspects of science including including particle physics, big data, robotics, palaeontology, marine biology and space exploration.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2138895-Reviews-ArtScience_Museum_at_Marina_Bay_Sands-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "6 Bayfront Avenue",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018974",
+        "address_string": "6 Bayfront Avenue, Singapore 018974 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.286262",
+      "longitude": "103.859245",
+      "timezone": "Asia/Singapore",
+      "email": "museumenquiries@marinabaysands.com",
+      "phone": "+65 6688 8888",
+      "website": "http://www.marinabaysands.com/museum.html",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2138895-ArtScience_Museum_at_Marina_Bay_Sands-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#88 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "88"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "1776",
+      "review_rating_count": {
+        "1": "88",
+        "2": "101",
+        "3": "213",
+        "4": "589",
+        "5": "785"
+      },
+      "photo_count": "2741",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2138895-m66827-Reviews-ArtScience_Museum_at_Marina_Bay_Sands-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 19:00",
+          "Tuesday: 10:00 - 19:00",
+          "Wednesday: 10:00 - 19:00",
+          "Thursday: 10:00 - 19:00",
+          "Friday: 10:00 - 21:00",
+          "Saturday: 10:00 - 21:00",
+          "Sunday: 10:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Specialty Museums",
+              "localized_name": "Specialty Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622528",
+          "name": "Bayfront"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "38"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "422"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "198"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "548"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "219"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "6 Bayfront Avenue",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018974",
+        "address_string": "6 Bayfront Avenue, Singapore 018974 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "SAM at 8Q & Singapore Art Museum": [
+    {
+      "location_id": "310899",
+      "name": "Singapore Art Museum",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/47/24/14/singapore-art-museum.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/5a/3f/b8/installation-of-michael.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/5a/3f/b6/installation-of-hazel.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/5a/3f/ac/mural-on-the-facade-of.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/5a/3f/ab/installation-view-of.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Brow high curation",
+          "text": "Singapore Art Museum, Tanjung Pagar Districtpark: This popped up on our radar as we cycled to Sentosa and what a squeal of a find! SAM is local art lovers’ paradise and even though SAM at Bras Bash has since shuttered, it has a new address in the old buildings facing PSA. Covering an area on the first and third floor, staff are extremely sweet and the art standards always brow high. #eatstylishtravelstylish"
+        },
+        {
+          "title": "Outstanding use of the space…",
+          "text": "…and some amazing things to see AND do! First off, the LEGO city which all visitors can contribute to is one of the very best museum features I have ever seen, it’s amazing and the current main show by a Danish artist is pretty wonderful too, particularly the water vapour projection room. Definitely worth visiting, somewhere very different from the usual SG tourist spots as well."
+        },
+        {
+          "title": "Nice experience",
+          "text": "First time visiting. Came with friends.Nice place to be, seen the amazing artworks on display.  Definately will be back for more !"
+        },
+        {
+          "title": "A must go whilst in Singapore",
+          "text": "Absolutely love this place! I recommend anyone who is in Singapore to go and visit. Wonderful curated artwork which was great to get to know some of the very talented local artists. I love the artworks of Sarah Choo Jing! Cant wait to be back"
+        },
+        {
+          "title": "Wall Mural reflecting our history and nature",
+          "text": "Singapore Art Museum’s buildings were once home to Catholic boys' schools – St. Joseph’s Institution on Bras Basah Road and Catholic High School on Queen Street.\nBoth are presently closed for renovation.\nHowever, outside the Singapore Art Museum at 8Q (the former Catholic High School), there is a site-specific large mural by artists, Darel Seow and Lee Xin Li.\nThis mural is titled An Unnatural History.  This mural combines Darel Seow’s passion for natural history and storytelling, and Lee Xin Li’s interest in heritage and architecture. \nThere is a \"An Unnatural History\" website, where one take a step back into history and see which of these storied landmarks can be identified as well as the 168 species of animals on the murals.  \nSadly this mural was only for a temporary period until 6 June."
+        }
+      ],
+      "description": "Singapore Art Museum opened in 1996 as the first art museum in Singapore. Also known as SAM, the museum presents contemporary art from a Southeast Asian perspective for artists, art lovers and the art curious in multiple venues across the island, including a new anchor venue in the historic port area of Tanjong Pagar. SAM’s space at Tanjong Pagar Distripark houses expansive galleries for bold art presentations, a coffee bookshop by the port, and versatile spaces for programmes and collaborations. SAM is building one of the world's most important public collections of Southeast Asian contemporary art, with the aim of connecting the art and the artists to the public and future generations through exhibitions, programmes, and meaningful encounters with contemporary art.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d310899-Reviews-Singapore_Art_Museum-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "39 Keppel Rd",
+        "street2": "#01-02 Tanjong Pagar Distripark",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "089065",
+        "address_string": "39 Keppel Rd #01-02 Tanjong Pagar Distripark, Singapore 089065 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.271957",
+      "longitude": "103.836754",
+      "timezone": "Asia/Singapore",
+      "email": "enquiries@singaporeartmuseum.sg",
+      "phone": "+65 6697 9730",
+      "website": "http://www.singaporeartmuseum.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d310899-Singapore_Art_Museum-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#104 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "104"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "519",
+      "review_rating_count": {
+        "1": "26",
+        "2": "27",
+        "3": "101",
+        "4": "183",
+        "5": "182"
+      },
+      "photo_count": "519",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d310899-m66827-Reviews-Singapore_Art_Museum-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 19:00",
+          "Tuesday: 10:00 - 19:00",
+          "Wednesday: 10:00 - 19:00",
+          "Thursday: 10:00 - 19:00",
+          "Friday: 10:00 - 19:00",
+          "Saturday: 10:00 - 19:00",
+          "Sunday: 10:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Art Museums",
+              "localized_name": "Art Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622372",
+          "name": "Museum"
+        },
+        {
+          "location_id": "15622424",
+          "name": "Bras Basah"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "10"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "108"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "113"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "68"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "82"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "39 Keppel Rd",
+        "street2": "#01-02 Tanjong Pagar Distripark",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "089065",
+        "address_string": "39 Keppel Rd #01-02 Tanjong Pagar Distripark, Singapore 089065 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Jamae Mosque (Masjid Chulia) Singapore": [
+    {
+      "location_id": "379355",
+      "name": "Jamae Mosque",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/06/ca/75/36/jamae-mosque-october.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/b0/0a/d3/filename-cimg0191-jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2c/b4/e9/24/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2c/b4/e9/23/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/28/3e/c8/temple-exterior.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Original mosque dating to 1827.",
+          "text": "This is one of Singapore's oldest mosques, dating to 1827 to serve Chulia migrants. The name board is titled 'Masjid Jamae (Chulia)' in recognition of the Tamil Muslims from Southern India who built three mosques in the area. We could not visit as the building is undergoing renovations. It has a short street front; the entrance gate flanked by minarets and retains its original form."
+        },
+        {
+          "title": "Positive Aspects",
+          "text": "This historical mosque is located near the Chinatown MRT station. The ambience is not crowded, disgusting and noisy."
+        },
+        {
+          "title": "Beautiful seafoam green mosque",
+          "text": "This is Muslim Mosque in Chinatown area.  While we were not able to go inside, we enjoyed the exterior.  What is so interesting is this is just down the street from a Hindu Temple and the Buddha Tooth Relic Temple.  Three religions next to each other."
+        },
+        {
+          "title": "Mosque with pagoda style towers",
+          "text": "This mosque is very close to the Chinatown area on the main street of South Bridge Road. Were it not for the two pagoda style towers at the front of the building, it would be a rather innocuous looking building. There’s not much to see inside because visitors are limited to walking around the corridor which is just full of information about Islam and proselytisation. So unless you’ve literally never encountered Islam, then stick to admiring the building from the outside only."
+        },
+        {
+          "title": "Plain Mosque with impressive towers",
+          "text": "Wednesday 23rd October and we were sightseeing and exploring in Chinatown and we visited the Holy Place.\n\nAt the front of the Mosque, there are 2 impressive tall turrets.The interior is a simple design and rather plain.\n\nAt the time of our visit there were some people praying in the Mosque, we did not want to intrude or disturb them, so we had a quick look around and left.\n\nFor those visitors who not dressed appropriately to enter the Mosque, there is clothing available to borrow. Also visitors are asked to remove their shoes."
+        }
+      ],
+      "description": "If you’re looking for something a little different, this is the mosque to visit. The site's architectural style is eclectic, and the intricately designed palace façade features tiny doors and cross-shaped windows.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d379355-Reviews-Jamae_Mosque-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "218 South Bridge Road Masjid Jamae (Chulia)",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "058767",
+        "address_string": "218 South Bridge Road Masjid Jamae (Chulia), Singapore 058767 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.2832",
+      "longitude": "103.84536",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6221 4165",
+      "website": "http://www.yoursingapore.com/content/traveller/en/browse/see-and-do/culture-and-heritage/places-of-worship/jamae-mosque.html?TAHotelCode=114",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d379355-Jamae_Mosque-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#201 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "201"
+      },
+      "rating": "3.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.5-66827-5.svg",
+      "num_reviews": "101",
+      "review_rating_count": {
+        "1": "0",
+        "2": "1",
+        "3": "43",
+        "4": "41",
+        "5": "16"
+      },
+      "photo_count": "174",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d379355-m66827-Reviews-Jamae_Mosque-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Sacred & Religious Sites",
+              "localized_name": "Sacred & Religious Sites"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622374",
+          "name": "Outram"
+        },
+        {
+          "location_id": "15622676",
+          "name": "Central Business District"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291616",
+          "name": "Chinatown"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "3"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "28"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "30"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "15"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "11"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "218 South Bridge Road Masjid Jamae (Chulia)",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "058767",
+        "address_string": "218 South Bridge Road Masjid Jamae (Chulia), Singapore 058767 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Institute of Contemporary Arts Singapore": [
+    {
+      "location_id": "324550",
+      "name": "National Museum of Singapore",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/45/9d/0f/national-museum-of-singapore.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/18/ba/ee/4e/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/18/ba/eb/df/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/ff/f6/74/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/ff/f6/73/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Don't miss the chicken curry :-)",
+          "text": "To be honest, I was a bit miffed after buying a ticket to find that most of the museum seemed to be closed except for one permanent gallery and a temporary exhibition, but they were both excellent so it was fine. The permanent gallery is the story of Singapore from pre-history to now which is very well illustrated and laid out. The temporary exhibition was photography of the tribes of the Amazon and was superb. The real high point though was the chicken curry in the cafe which was absolutely excellent!"
+        },
+        {
+          "title": "Look at local history via the eyes of locals and the Amazonas exertion",
+          "text": "It’s an interesting site for every visitor of the town.\nIt is not made in a very professional way, but it is interesting to view in the eyes of locals the history of Singapore \n\nIf you have some spare time, climb up the mountain and go see the place"
+        },
+        {
+          "title": "Definitely worth a visit",
+          "text": "They had 2 very good exhibits; Amazon & History of Singapore. However, the museum is under renovation so they have a weird entrance, one small bathroom and not much common area to sit and relax etc"
+        },
+        {
+          "title": "A Fascinating Journey Through Singapore’s History",
+          "text": "A great place to learn about the country’s rich history in an engaging way. The exhibits are well-curated, with a mix of artifacts, interactive displays, and immersive storytelling. The building itself is beautiful, blending history with modern design. It’s definitely worth a visit if you enjoy culture and history!"
+        },
+        {
+          "title": "A  rainy day experience ",
+          "text": "This is a well presented and informative museum, on the small side but well laid out. Takes you on a journey of Singapore evolution with informative text, photographs and objects. The staff were helpful a welcoming. It was easy to spend a couple of hours here, we did not visit the Amazonian exhibit."
+        }
+      ],
+      "description": "With a history dating back to its inception in 1887, the National Museum of Singapore is the nation's oldest museum with a progressive mind. Its galleries adopt cutting-edge and multi-perspective ways of presenting history and culture to redefine conventional museum experience. A cultural and architectural landmark in Singapore, the Museum hosts innovative festivals and events all year round-the dynamic Night Festival, visually arresting art installations, as well as amazing performances and film screenings-in addition to presenting thought-provoking exhibitions involving critically important collections of artefacts. The programming is supported by a wide range of facilities and services including F&B, retail and a Resource Centre. The National Museum of Singapore re-opened in December 2006 after a three-year redevelopment, and celebrated its 125th anniversary in 2012. The Museum refreshed its permanent galleries and re-opened them on 19 September 2015 for Singapore's Golden Jubilee.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d324550-Reviews-National_Museum_of_Singapore-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "93 Stamford Road National Museum of Singapore",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "178897",
+        "address_string": "93 Stamford Road National Museum of Singapore, Singapore 178897 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.296596",
+      "longitude": "103.84865",
+      "timezone": "Asia/Singapore",
+      "email": "nhb_nm_corpcomms@nhb.gov.sg",
+      "phone": "+65 6332 3659",
+      "website": "http://nationalmuseum.sg/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d324550-National_Museum_of_Singapore-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#35 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "35"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "2952",
+      "review_rating_count": {
+        "1": "31",
+        "2": "62",
+        "3": "271",
+        "4": "1037",
+        "5": "1551"
+      },
+      "photo_count": "2931",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d324550-m66827-Reviews-National_Museum_of_Singapore-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 19:00",
+          "Tuesday: 10:00 - 19:00",
+          "Wednesday: 10:00 - 19:00",
+          "Thursday: 10:00 - 19:00",
+          "Friday: 10:00 - 19:00",
+          "Saturday: 10:00 - 19:00",
+          "Sunday: 10:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Specialty Museums",
+              "localized_name": "Specialty Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622372",
+          "name": "Museum"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        },
+        {
+          "location_id": "15622424",
+          "name": "Bras Basah"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "93"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "920"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "536"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "475"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "397"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "TopAttractions"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        },
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "93 Stamford Road National Museum of Singapore",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "178897",
+        "address_string": "93 Stamford Road National Museum of Singapore, Singapore 178897 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Singapore Flyer": [
+    {
+      "location_id": "678639",
+      "name": "Singapore Flyer",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/97/54/a5/r65-memories-at-time.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/97/54/a8/infinity-space-at-time.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/97/54/a0/the-iconic-singapore.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/97/54/ae/river-of-time-at-time.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1a/c9/85/9e/re-discover-the-height.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "What a great ride, and one of the best views in town.",
+          "text": "Great ride/ experience, some of the best views in town and very informative. Kids loved every minute of this experience."
+        },
+        {
+          "title": "Recommend going at twilight for day and night views",
+          "text": "The views from the top-most point are really good. Would recommend going there at twilight so that you can see views of both day and night as the lights come on. The F1 track can also be seen clearly, especially the main straight."
+        },
+        {
+          "title": "Good",
+          "text": "Good place to view city from top. It wasn't crowdy, so no long waiting time. Anoying that before actual ride you must go through \"mandatory\" time-capsule exbition halls.\nOverall - recommend as one of must-do in city."
+        },
+        {
+          "title": "Great views over the city",
+          "text": "Though quite pricey for the 40 minute circuit, the views from the top are worth it. I did not like the obligatory \"Time Capsule\" passage we had to go through to get to the actual ride!  We arrived on a cloudy afternoon and there was no line, no wait and we had the capsule to ourselves, which was lots of fun!"
+        },
+        {
+          "title": "The interactive bit was a let down",
+          "text": "The interactive bit to start was a let down, but to be fair we only wanted to go on the big wheel! Great views of Singapore, wouldn’t go back, but I suppose worth it for seeing the sights."
+        }
+      ],
+      "description": "At 165 metres tall, Singapore Flyer is a masterpiece of urban architecture and engineering that showcases not only the mesmerizing cosmopolitan cityscape of the tropical Lion City, but even the surrounding islands of Indonesia and parts of Malaysia in all their glory. In addition to offering panoramic views of Singapore's cosmopolitan cityscape, guests can also indulge in a flute of champagne, or savour the iconic Singapore Sling whilst hosted in a special themed capsule. Diners seeking both privacy and luxury can opt for a multi-sensory treat unlike any other with our Premium Sky Dining Flight, complete with a four-course dinner and an in-flight host.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d678639-Reviews-Singapore_Flyer-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "30 Raffles Avenue",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "039803",
+        "address_string": "30 Raffles Avenue, Singapore 039803 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.289469",
+      "longitude": "103.8631",
+      "timezone": "Asia/Singapore",
+      "email": "media@singaporeflyer.com",
+      "phone": "+65 6333 3311",
+      "website": "http://www.singaporeflyer.com/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d678639-Singapore_Flyer-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#6 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "6"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "17460",
+      "review_rating_count": {
+        "1": "140",
+        "2": "276",
+        "3": "1961",
+        "4": "5765",
+        "5": "9318"
+      },
+      "photo_count": "12309",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d678639-m66827-Reviews-Singapore_Flyer-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "2200"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 22:00",
+          "Tuesday: 10:00 - 22:00",
+          "Wednesday: 10:00 - 22:00",
+          "Thursday: 10:00 - 22:00",
+          "Friday: 10:00 - 22:00",
+          "Saturday: 10:00 - 22:00",
+          "Sunday: 10:00 - 22:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Observation Decks & Towers",
+              "localized_name": "Observation Decks & Towers"
+            },
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622655",
+          "name": "Marina Centre"
+        },
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "644"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "5642"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "1144"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "4807"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "2474"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "TopAttractions"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        },
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "30 Raffles Avenue",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "039803",
+        "address_string": "30 Raffles Avenue, Singapore 039803 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Marina Bay SandsÂ®": [
+    {
+      "location_id": "1177497",
+      "name": "Marina Bay",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/d7/53/1f/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/b8/fa/31/photo7jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/b8/fa/30/photo6jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/b8/fa/2e/photo4jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/b8/fa/2f/photo5jpg.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Symbolically Iconic",
+          "text": "No matter where you view it, the Marina Bay Sands building is iconic Singapore. Views out from the bay itself or Gardens By The Bay will be sure to delight. Selfies galore!"
+        },
+        {
+          "title": "Great Area to Stay if You Enjoy Walking a Waterfront Promenade",
+          "text": "A very pretty area to walk particularly in evening when city lights up. Mandarin Oriental hotel is very lovley, Makansutra Gluttons Bay's 12 hawker stalls have a great range of top-quality food, waterfront bars with live music and casual food and drinks make for a great evening. Walking fully around Marina Bay takes about an hour and ten minutes. MRT statins take you around the rest of the city easily."
+        },
+        {
+          "title": "Amazing",
+          "text": "Marina Bay is an absolutely stunning destination! The breathtaking skyline, iconic landmarks like Marina Bay Sands and Gardens by the Bay, and the vibrant atmosphere make it a must-visit. Whether you’re enjoying a relaxing stroll along the waterfront, watching the mesmerizing light shows, or dining at world-class restaurants, there’s always something magical about this place. The combination of modern architecture, beautiful nature, and lively nightlife creates an unforgettable experience. If you’re visiting Singapore, Marina Bay is definitely a highlight you shouldn’t miss!"
+        },
+        {
+          "title": "Mild-Mannered Comfortable Asian Felt Crazy Rich",
+          "text": "I booked a room overlooking the Gardens by the Bay to celebrate our wedding anniversary in Singapore during Valentine's Day for 2 nights. We were able to check in early & Andy - the receptionist really came through for us! He recognized from my booking that we're celebrating our anniversary so he upgraded us to a suite room, with the same view overlooking the Gardens on 30th floor. OMG, our suite room was spectacular!!! The housekeeping staff was also very efficient and welcoming. Making sure that we're always taken care of as far as stocking our room every time we're gone, the things we used gets replaced & cleaned up. We're glad to spend this much booking this hotel. It's a one in a lifetime experience. The infinity pool was also amazing! I would definitely recommend to everyone to celebrate their special day here at the MBS hotel. Everything is perfect and breathtaking!!!\n\nThe Rise buffet was amazing! We had dinner and very pleased with the food selection and service. Make sure you sign up for Marina Bay Sands app, you get rewards points/cash that you can use to any of their restaurants & stores, just make sure to present your membership number every time you pay. \n\nLastly,  hands up  to Andy at the hotel reception. He really came through for us. Made our anniversary very memorable and special!!! Employee of the Year"
+        },
+        {
+          "title": "In the future, I would really want to stay at this hotel.",
+          "text": "I was given the opportunity to tour the Marina Bay Sands Hotel. It was breathtaking. I was allowed to go outdoors and enjoy the spectacle at night. The artwork and soundtrack were amazing. I also went to the top-floor Wolfgang Puck restaurant's bar. The beverages were excellent, the service was excellent, and the view was breathtaking!"
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d1177497-Reviews-Marina_Bay-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Marina Boulevard",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018980",
+        "address_string": "Marina Boulevard, Singapore 018980 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.28779",
+      "longitude": "103.866554",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6329 3535",
+      "website": "https://www.ura.gov.sg/Corporate/Get-Involved/Shape-A-Distinctive-City/Explore-Our-City/Marina-Bay",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d1177497-Marina_Bay-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#5 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "5"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "13200",
+      "review_rating_count": {
+        "1": "39",
+        "2": "59",
+        "3": "603",
+        "4": "3885",
+        "5": "8614"
+      },
+      "photo_count": "9435",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d1177497-m66827-Reviews-Marina_Bay-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Marinas",
+              "localized_name": "Marinas"
+            },
+            {
+              "name": "Bodies of Water",
+              "localized_name": "Bodies of Water"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622527",
+          "name": "Central"
+        },
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "881"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "4122"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "1275"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "2473"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "2068"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "TopAttractions"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        },
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "Marina Boulevard",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018980",
+        "address_string": "Marina Boulevard, Singapore 018980 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Marina Barrage": [
+    {
+      "location_id": "1823698",
+      "name": "Marina Barrage",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/19/be/fc/f4/20191019-210138-largejpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/04/73/6b/7b/marina-barrage.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/90/79/4b/der-300m-lange-damm-der.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/60/c0/9c/the-view-from-the-top.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/93/ba/e5/marina-barrage.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Awesome View",
+          "text": "Located close to Gardens by the bay, an amazing place to go. Fantastic view of Singapore from here. Good place to take nice photos."
+        },
+        {
+          "title": "Sky Garden Park",
+          "text": "Nice place for photos & picnic. Was there on a Saturday morning and there were many people cycling, jogging and the road from Marina Barrage to Gardens by the Bay & MBS is linked within a 20-30 mins walk."
+        },
+        {
+          "title": "Incredible View at Marina Barrage",
+          "text": "Not too far from Gardens by the Bay lies the Marina Barrage, one of the standout spots we highly recommend.\n\nThe Marina Barrage isn't merely a dam; it also serves as a place for outdoor activities and offers a wonderful viewpoint that, in our opinion, shouldn't be missed.\n\nWith its convenient walking distance from the center of Gardens by the Bay, it rewards visitors with a breathtaking view. From Marina Barrage, you can see the entirety of Gardens by the Bay against the backdrop of Marina Bay Sands—a truly stunning sight.\n\nWe spent hours at Marina Barrage, enjoying that incredible view, and already miss the moments spent there."
+        },
+        {
+          "title": "Hidden gem full of insights into sustainability.",
+          "text": "On our way via MRT to Gardens by the Bay we walked down to the opening and on our  right we found the Marina Barrage. What an interesting place based on sustainability and what Singapore has done and achieved and will do into the future. This is a free exhibition and can take as long as you want to read/look at exhibits.\nIts highly recommended to detour here before you go into the gardens and see what has been done thus far. We were glad to find this place. We spent a few hors before walking around the gardens."
+        },
+        {
+          "title": "Great views",
+          "text": "Well worth a visit as it has stunning views of the whole city. Also has views of the barrage which separates the freshwater from the seawater. It's a steep ramp to walk up but there is also a lift which goes straight to the top"
+        }
+      ],
+      "description": "Be captivated by the bright lights of the Singapore Flyer and the Central Business District skyline against the sky at sunset, reflected in the still waters of the Marina Barrage. This Reservoir in the City was created with three key benefits, to provide water supply, flood control and a lifestyle attraction.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d1823698-Reviews-Marina_Barrage-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "8 Marina Gardens Dr",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018951",
+        "address_string": "8 Marina Gardens Dr, Singapore 018951 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.280743",
+      "longitude": "103.87111",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6514 5959",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d1823698-Marina_Barrage-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#48 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "48"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "692",
+      "review_rating_count": {
+        "1": "2",
+        "2": "16",
+        "3": "75",
+        "4": "320",
+        "5": "279"
+      },
+      "photo_count": "757",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d1823698-m66827-Reviews-Marina_Barrage-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0000"
+            },
+            "close": {
+              "day": 1,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0000"
+            },
+            "close": {
+              "day": 2,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0000"
+            },
+            "close": {
+              "day": 3,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0000"
+            },
+            "close": {
+              "day": 4,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0000"
+            },
+            "close": {
+              "day": 5,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0000"
+            },
+            "close": {
+              "day": 6,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0000"
+            },
+            "close": {
+              "day": 7,
+              "time": "2359"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 00:00 - 23:59",
+          "Tuesday: 00:00 - 23:59",
+          "Wednesday: 00:00 - 23:59",
+          "Thursday: 00:00 - 23:59",
+          "Friday: 00:00 - 23:59",
+          "Saturday: 00:00 - 23:59",
+          "Sunday: 00:00 - 23:59"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            }
+          ]
+        },
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Marinas",
+              "localized_name": "Marinas"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "13210711",
+          "name": "Marina South"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "23"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "121"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "83"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "153"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "145"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "8 Marina Gardens Dr",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018951",
+        "address_string": "8 Marina Gardens Dr, Singapore 018951 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Henderson Waves Bridge": [
+    {
+      "location_id": "3561693",
+      "name": "Henderson Waves",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/1b/26/36/cc/the-view-back-towards.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/03/1d/8c/94/henderson-waves.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/19/55/77/ba/henderson-waves.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/16/d9/27/3c/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/14/66/0b/59/here-we-are.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Let down",
+          "text": "The walk is closed until July 2026 so whilst Henderson waves is open and nice the adjoining walks being closed makes the experience poor overall.\nHenderson waves is a 15 min walk - if close do it but if not don’t travel"
+        },
+        {
+          "title": "Not worth your time",
+          "text": "It’s a glorified bridge that is quite out of your way. Not worth the visit, even if you have an abundance of time. Not wheelchair friendly for those with babies or mobility scooters/wheelchairs."
+        },
+        {
+          "title": "Cool bridge which offers gorgeous views",
+          "text": "It’s hot and sticky but it is well worth it for the views! \n\nThe bridge is so unique it’s great to see the architecture. It offers lovely views of Singapore.\n\nWell worth the effort!"
+        },
+        {
+          "title": "Not bad for a view if you like hiking",
+          "text": "Views were not as amazing as we had thought. It was quite a shlep to get there and probably not worth the effort in its own right but a good jumping off point for Mount Faber and the cable car to Sentosa"
+        },
+        {
+          "title": "Unique Bridge",
+          "text": "The best time to visit for me was early on a weekday morning.  Lower relative temps at that time plus overcast made the trek to Henderson Wave nicer.\n\nIf you can take a grab car or taxi and get dropped off in the parking lot.  From there it was a paved path up which was a much easier approach than the stairs near the bus stop.\n\nThe wave itself was a combination of wood and metal with views from both sides.  The undulating wave design gave the bridge its  distinctive look though it’s built like most bridges.  To get a better photo and view of the bridge it was best viewed from the middle of the staircase leading down to Henderson Road.\n\nIt took me around 10 minutes to cross including stops to take photos as well as read the Discovery Walk signs that gave a quick history but also point out some of the more significant buildings from that vantage point.\n\nFrom here, I continued my walk to Fraser Point at the top of Mount Fraser Park and the MarangTrail to the Harbourfront MRT station."
+        }
+      ],
+      "description": "Henderson Waves, the highest pedestrian bridge in Singapore, connects Mount Faber Park to Telok Blangah Hill Park.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d3561693-Reviews-Henderson_Waves-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "221 Henderson Road",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "159557",
+        "address_string": "221 Henderson Road, Singapore 159557 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.276023",
+      "longitude": "103.81539",
+      "timezone": "Asia/Singapore",
+      "website": "https://beta.nparks.gov.sg/visit/parks/telok-blangah-hill-park/special-features/henderson-waves",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d3561693-Henderson_Waves-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#58 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "58"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "642",
+      "review_rating_count": {
+        "1": "1",
+        "2": "13",
+        "3": "73",
+        "4": "284",
+        "5": "271"
+      },
+      "photo_count": "842",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d3561693-m66827-Reviews-Henderson_Waves-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0000"
+            },
+            "close": {
+              "day": 1,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0000"
+            },
+            "close": {
+              "day": 2,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0000"
+            },
+            "close": {
+              "day": 3,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0000"
+            },
+            "close": {
+              "day": 4,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0000"
+            },
+            "close": {
+              "day": 5,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0000"
+            },
+            "close": {
+              "day": 6,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0000"
+            },
+            "close": {
+              "day": 7,
+              "time": "2359"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 00:00 - 23:59",
+          "Tuesday: 00:00 - 23:59",
+          "Wednesday: 00:00 - 23:59",
+          "Thursday: 00:00 - 23:59",
+          "Friday: 00:00 - 23:59",
+          "Saturday: 00:00 - 23:59",
+          "Sunday: 00:00 - 23:59"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Bridges",
+              "localized_name": "Bridges"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622606",
+          "name": "Telok Blangah Drive"
+        },
+        {
+          "location_id": "15622331",
+          "name": "Bukit Merah"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "8"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "171"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "105"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "108"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "149"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "221 Henderson Road",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "159557",
+        "address_string": "221 Henderson Road, Singapore 159557 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Pinnacle@Duxton": [
+    {
+      "location_id": "3512810",
+      "name": "The Pinnacle @ Duxton",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/04/12/3b/01/the-pinnacle-duxton.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/49/d9/3c/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/49/d9/3b/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/49/d9/3a/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/49/d9/39/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Great views of the city.",
+          "text": "Go to block G Cantonment Road. Ticket office is in an alley between shops, see pics. Can get tickets and pay with card outside ticket office.\nGood different views of the city without tourists. Very peaceful, worth a visit."
+        },
+        {
+          "title": "A quiet getaway",
+          "text": "I am not sure whether to write this review! We liked this place as it was quiet with hardly any tourists. It has spectacular views, although not of the marina bay area. Nice place to spend a relaxing day. Keep in mind that there is a 150 pax cap per day so the place might be closed by evenings."
+        },
+        {
+          "title": "Amazing 360 degree views of Singapore from the 50th floor",
+          "text": "I am rating this 5:5 simply for the amazing views from the top; however it was quite a mission to actually get there. \n\nWe found the building quite easily - it’s hard to miss being so tall - but finding the entrance was quite tricky. We had to find building G, and then were turned away because we didn’t have cash!  Being determined to do this we asked where the nearest cash point ATM was (over and along the road) so armed with our cash ($6 per person) we made our way back. We then got tripped up because we didn’t have one of the ID documents needed to access the turnstile (not sure what they were, they seemed to be travel docs). I think the man in the ticket office felt sorry for us as he handed us his own personal access pass if we left behind a driving licence as collateral. \n\nOur persistence paid off and we were blown away by the views. You can walk all around the top of all 6 towers. Mainly this was the residents doing this at the time we came (6pm) so it wasn’t at all crowded"
+        },
+        {
+          "title": "Enjoy panoramic sunset view & city views from Singapore’s Tallest public housing project",
+          "text": "Yes, in case you may not be aware, The Pinnacle @Duxton is Singapore’s tallest public housing project.\n\nFirst thing first - how to get there?\n\nThere are two MRT stations nearby: Tanjong Pagar (East West Line, green colour) and Maxwell (Thomson East Coast Line, brown colour).\n\nI took the MRT to Maxwell Station as I’d planned to have an early dinner before going to the Pinnacle. There is a hawker centre, Maxwell Food Centre, which is situated above the Maxwell Station. If you go to the hawker centre before 6.00pm, it will be relatively easy to get a table.\n\nFrom Maxwell Station it’s an easy 10 minute walk to The Pinnacle. \n\nBefore you get there, I will suggest that each person has a EZ Link card (which you use for taking buses and MRT rides) and a Singapore phone (for emergency, in case you need to make a call).\n\nWhen you reach The Pinnacle @Duxton, do note that this is a big project, look for Block 1G. \n\nThen take the lift to Level 1 (you are most likely to arrive at Level 3, which you may think that it’s the ground floor, but it’s not).\n\nAt Level 1, look for the tiny Security Office or MA’s office (follow the white signboard). The duty security guard will ask you for SGD 6.00 per person and your EZ Link card.\n\nThen head to the lift lobby, take Lift A or B to Level 50. \n\nThere is a tall turnstile at Level 50, which you will need to tap using your EZ Link card to “unlock” the gate.\n\nWhen I tried to exit when I was there, the turnstile didn’t work well so I had to call the Security Office (phone number listed at the gate) for them to remotely unlock the gate for me. So it’ll be handy if you have a Singapore phone with you, just in case you need to call for help.\n\nThe best time to go is 6.30pm to enjoy the sunset view. \n\nAt the sky deck you could take a leisurely stroll and take in the views of the container port, Chinatown and the CBD. It’s definitely worth a visit."
+        },
+        {
+          "title": "Best view in Singapore",
+          "text": "So this is a (Huge) observation deck on the top floor of the Duxton housing complex.  It takes about 30 min to walk the entire deck and you get 360 degree views of Singapore 50 floors up!  And its only 6 SGD."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d3512810-Reviews-The_Pinnacle_Duxton-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 Cantonment Road The Pinnacle @ Duxton",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "080001",
+        "address_string": "1 Cantonment Road The Pinnacle @ Duxton, Singapore 080001 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.277333",
+      "longitude": "103.84125",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 8683 7760",
+      "website": "http://www.pinnacleduxton.com.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d3512810-The_Pinnacle_Duxton-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#79 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "79"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "257",
+      "review_rating_count": {
+        "1": "5",
+        "2": "6",
+        "3": "26",
+        "4": "79",
+        "5": "141"
+      },
+      "photo_count": "426",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d3512810-m66827-Reviews-The_Pinnacle_Duxton-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0900"
+            },
+            "close": {
+              "day": 1,
+              "time": "2130"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0900"
+            },
+            "close": {
+              "day": 2,
+              "time": "2130"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0900"
+            },
+            "close": {
+              "day": 3,
+              "time": "2130"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0900"
+            },
+            "close": {
+              "day": 4,
+              "time": "2130"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0900"
+            },
+            "close": {
+              "day": 5,
+              "time": "2130"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0900"
+            },
+            "close": {
+              "day": 6,
+              "time": "2130"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0900"
+            },
+            "close": {
+              "day": 7,
+              "time": "2130"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 09:00 - 21:30",
+          "Tuesday: 09:00 - 21:30",
+          "Wednesday: 09:00 - 21:30",
+          "Thursday: 09:00 - 21:30",
+          "Friday: 09:00 - 21:30",
+          "Saturday: 09:00 - 21:30",
+          "Sunday: 09:00 - 21:30"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622374",
+          "name": "Outram"
+        },
+        {
+          "location_id": "15622676",
+          "name": "Central Business District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "2"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "81"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "51"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "34"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "45"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "1 Cantonment Road The Pinnacle @ Duxton",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "080001",
+        "address_string": "1 Cantonment Road The Pinnacle @ Duxton, Singapore 080001 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Hajjah Fatimah Mosque": [
+    {
+      "location_id": "338358",
+      "name": "Hajjah Fatimah Mosque",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/2b/72/d8/d2/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/1c/25/aa/hajjah-fatimah-mosque.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2b/72/d8/ff/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2b/72/d8/ed/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2d/b3/b1/77/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A special mosque",
+          "text": "Dating back to 1846 , this mosque is built by a wealthy businesswoman. It is named after her.  It is probably the only mosque named after a woman in the world.\n\nIts architecture is simple and elegant, combines Muslim and European architectural styles which is another major feature.\n\nIn front of the temple is a a serene grassland. It is not a popular tourist spot, there are few tourists.  It is quiet and peaceful."
+        },
+        {
+          "title": "Positive Aspects",
+          "text": "This historical mosque is located not far away from the Nicoll Highway MRT station. The surrounding is calm and clean. The view is great."
+        },
+        {
+          "title": "A unique minaret dubbed as \"Leaning Tower of Singapore\"",
+          "text": "This mosque was built by a wealthy Malacca-born businesswoman in gratitude for several escapes from danger.\nThe wooden window balcony above the two-storey entrance gate reflects a Moorish design.  The parapets of the minaret are inset with green glazed Chinese porcelain tiles.  The minaret consists of an eight-sided peak atop a two-tiered octagonal tower on a square base.  There are Doric capitals on the first three tiers of the minaret.  The minaret tower is believed to be a copy of the tower spire erected on the first St Andrew's Church.\nThe minaret tilted slightly due to the sandy soil on which it was built, leading it to be nicknamed \"Leaning Tower of Singapore\".  This mosque was gazetted as a national monument in 1973."
+        },
+        {
+          "title": "historic mosque in singapore",
+          "text": "one of the historic mosque in singapore. well designed and located in kampong glam. friday sholat in this hotel you can feel the diversity and great feeling "
+        },
+        {
+          "title": "Between Skyscrapers",
+          "text": "The mosque is between high building in a small park, open for visitors. During a visit pay respect  for true believers."
+        }
+      ],
+      "description": "Perhaps the most unusual feature you’ll notice here is a distinctive minaret designed by an unidentified European architect. The tower leans about six degrees off centre – making this one of the most unique sights in Singapore.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d338358-Reviews-Hajjah_Fatimah_Mosque-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "4001 Beach Road Hajjah Fatimah Mosque",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "199584",
+        "address_string": "4001 Beach Road Hajjah Fatimah Mosque, Singapore 199584 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.30287",
+      "longitude": "103.8629",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6297 2774",
+      "website": "http://www.yoursingapore.com/content/traveller/en/browse/see-and-do/culture-and-heritage/places-of-worship/hajjah-fatimah-mosque.html?TAHotelCode=118",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d338358-Hajjah_Fatimah_Mosque-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#291 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "291"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "39",
+      "review_rating_count": {
+        "1": "0",
+        "2": "1",
+        "3": "13",
+        "4": "13",
+        "5": "12"
+      },
+      "photo_count": "49",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d338358-m66827-Reviews-Hajjah_Fatimah_Mosque-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Sacred & Religious Sites",
+              "localized_name": "Sacred & Religious Sites"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622450",
+          "name": "Crawford"
+        },
+        {
+          "location_id": "15622361",
+          "name": "Kallang"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "9"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "13"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "6"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "4"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "4001 Beach Road Hajjah Fatimah Mosque",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "199584",
+        "address_string": "4001 Beach Road Hajjah Fatimah Mosque, Singapore 199584 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Haw Par Villa: Singapore Theme Park": [
+    {
+      "location_id": "324758",
+      "name": "Haw Par Villa",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/13/2a/ac/5a/tiger-balm-gardens.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/65/e8/be/surreal-wonderland-of.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/65/e8/af/the-grand-entrance-archway.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/65/e8/d1/virtues-vices-diorama.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/65/e8/ce/tiger-s-arch.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A shame that the staff are leaving and the park is not well publicised",
+          "text": "I've been to Haw Par Villa a few times as a child and took a friend who has lived in Singapore for many years but who had no clue what Haw Par Villa was. My friend was blown away by the richness of the Chinese culture depicted by the park grounds and said Haw Par Villa and the Singapore tourism agency should really publicise the park more. He felt it would be great for kids. As for me, I had read Tripadvisor reviews that going with a guided tour made all the difference so I kept waiting for a time I could go with a tour to visit the park. Sad to say, somehow all the permanent staff are leaving the park so the night tour was cancelled since end 2024 and the weekend 11am tour was also not available due to staff shortage on the day we went. We did manage to join a 10.30am Hell's Museum tour but I would say that the tour wasn't worth the hype. The \"death rites\" around the world (e.g. Zoroastrianism, Abrahamic faiths etc) educational piece does not work with Haw Par Villa. It adds little to the experience and is incongruous with Haw Par Villa being more a Chinese / Singaporean culture venue. I would suggest saying look Haw Par Villa is free to enter, so for the Hell's Court part, it is fair if we charge a S$10 fee for you to enter if you want to see the Hell's Court part.  I hope park management and the Singaporean authorities will keep Haw Par Villa a part of Singapore.  The free park grounds are well worth a leisurely 1-hour stroll especially with kids and I would suggest we pay $10 to see the Hell's Courts as well"
+        },
+        {
+          "title": "Eccentric home of Tiger Balm",
+          "text": "Well this place was a revelation.  When we arrived the whole place seemed like a deserted 1960s Butlins Holiday Park.  The sculptures in the park are a bit dilapidated but what fun!  We intended to visit Hell's Museum so finding the sculpture park was a bonus.  We were a little unsure about Hell's Museum as we thought it might be too religious/spiritual for us. However, it was the best thing we did in Singapore.  The tour explained different religions' views on death and the afterlife and the visit to the models of the Ten Courts of Hell was absolutely fascinating.  Entrance to the museum gives you 10% discount in the cafe.  It's probably a \"Marmite\" attraction but we loved it."
+        },
+        {
+          "title": "A unique and amazing experience",
+          "text": "An extremely interesting and different experience, unique and different, the Hells museum tour was extremely informative and different, well worth the price of the tickets at $20, the free guided tour given by Joanne was an added bonus"
+        },
+        {
+          "title": "I suggest an hour to an hour and a half because it's rather large.",
+          "text": "My first action was to enter Ten Courts of Hell, where I was horrified by the graphic sights showing the extremely cruel outcomes of sinners. Extremely graphic picture, but fascinating how different approaches are taken to dealing with offenders. If you have the courage, you may gaze into the mirror of truth and see how you appeared at the time, whether you were a saint or wicked. I was obviously bad for some reason since my reflection looked like the face of the devil. There is a wealth of iconography that illustrates several Chinese mythological tales, making it a wonderful place to take children to study."
+        },
+        {
+          "title": "Out of time",
+          "text": "This is billed as \"the last Asian theme park of its kind\",   and I can almost see why. For those truly interested in Chinese mythology, the colourful if very kitschy figures and displays may be of interest, but it just looked old, out of place and out of time. Entrance is free, but the place was almost empty on a Saturday lunchtime."
+        }
+      ],
+      "description": "Haw Par Villa - formerly known as the Tiger Balm Garden – is an 8.5-hectare Asian cultural park, the last of its kind in the world. Built in 1937, Singapore’s largest outdoor art gallery is the brainchild of Aw Boon Haw, millionaire philanthropist and marketing extraordinaire who gifted the world Tiger Balm. The eclectic park is a treasure trove of Asian culture, history, philosophy and religion – quirky yet enlightening at the same time. Since 2015, it is managed Journeys Pte Ltd, an award-winning heritage specialist passionate in preserving and bringing the heritage gem to greater heights.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d324758-Reviews-Haw_Par_Villa-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "262 Pasir Panjang Rd",
+        "street2": "1-min walk from Haw Par Villa MRT Station",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "118628",
+        "address_string": "262 Pasir Panjang Rd 1-min walk from Haw Par Villa MRT Station, Singapore 118628 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.283176",
+      "longitude": "103.781944",
+      "timezone": "Asia/Singapore",
+      "email": "hpv@journeys.com.sg",
+      "phone": "+65 6773 0103",
+      "website": "http://www.hawparvilla.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d324758-Haw_Par_Villa-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#64 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "64"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "943",
+      "review_rating_count": {
+        "1": "17",
+        "2": "40",
+        "3": "184",
+        "4": "370",
+        "5": "332"
+      },
+      "photo_count": "1906",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d324758-m66827-Reviews-Haw_Par_Villa-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0900"
+            },
+            "close": {
+              "day": 1,
+              "time": "2000"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0900"
+            },
+            "close": {
+              "day": 2,
+              "time": "2000"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0900"
+            },
+            "close": {
+              "day": 3,
+              "time": "2000"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0900"
+            },
+            "close": {
+              "day": 4,
+              "time": "2000"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0900"
+            },
+            "close": {
+              "day": 5,
+              "time": "2000"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0900"
+            },
+            "close": {
+              "day": 6,
+              "time": "2000"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0900"
+            },
+            "close": {
+              "day": 7,
+              "time": "2000"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 09:00 - 20:00",
+          "Tuesday: 09:00 - 20:00",
+          "Wednesday: 09:00 - 20:00",
+          "Thursday: 09:00 - 20:00",
+          "Friday: 09:00 - 20:00",
+          "Saturday: 09:00 - 20:00",
+          "Sunday: 09:00 - 20:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "amusement_parks",
+          "localized_name": "Water & Amusement Parks"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Historic Sites",
+              "localized_name": "Historic Sites"
+            }
+          ]
+        },
+        {
+          "name": "Water & Amusement Parks",
+          "localized_name": "Water & Amusement Parks",
+          "categories": [
+            {
+              "name": "Theme Parks",
+              "localized_name": "Theme Parks"
+            }
+          ]
+        },
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Gardens",
+              "localized_name": "Gardens"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622536",
+          "name": "Pasir Panjang 1"
+        },
+        {
+          "location_id": "15622357",
+          "name": "Queenstown"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "5"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "220"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "162"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "191"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "172"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "262 Pasir Panjang Rd",
+        "street2": "1-min walk from Haw Par Villa MRT Station",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "118628",
+        "address_string": "262 Pasir Panjang Rd 1-min walk from Haw Par Villa MRT Station, Singapore 118628 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "NUS Baba House - Singapore Peranakan Architecture": [
+    {
+      "location_id": "1857193",
+      "name": "NUS Baba House",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0f/fa/15/d4/photo1jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/06/cd/f3/27/family-hall.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/06/cd/f2/b7/nus-baba-house.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/06/cd/f2/b8/reception-hall.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0b/17/98/45/gallery-shot-of-study.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A Singapore highlight",
+          "text": "We would thoroughly recommend booking a tour to see NUS Baba House, a restored Peranakan house. The tour starts at 10am & they request you arrive beforehand. The area around this house is also Peranakan, so worth a mooch. The tour was about an hour but the guide made it so interesting & informative. I would say the best tour we have taken across SE Asia."
+        },
+        {
+          "title": "A slice of history",
+          "text": "This historical house was a highlight of my trip to Singapore. It gave such an insight to the Peranakan heritage of Singapore. \nOur guide -Shirley - I think was her name - was enthusiastic and so knowledgeable.  The tour was supposed to be an hour, but we were there for over 90 minutes. It was so engaging it didn’t feel that long. \nOnly 13 people can go on the tour at once so you must book. The tickets were somewhat misleading - so tours start at 10.00am. \nWe also found a cute little cafe down the street called Plain Vanilla which I would also recommend."
+        },
+        {
+          "title": "Something to do in Singapore if you have done the main tourist activities",
+          "text": "We were a large group of friends, all fairly well-exposed to touring and eating in Singapore, so we searched around for a slice of history. NUS Baba House was a great find. The Peranakan-style building reflects life in Singapore last century and was expertly explained to us by our guide.\n\nNeil Rd and surrounds are hidden gems in Singapore, off the regular tourist track, and walking around the area fully complements a tour of Baba House."
+        },
+        {
+          "title": "Beautiful Baba House",
+          "text": "I was surprised at how much I enjoyed this glimpse into Peranekan life in 1928. A beautifully restored home and a wonderful story. Special thanks to Mabel for sharing some extra “gossip” and history."
+        },
+        {
+          "title": "Must-see glimpse into the past",
+          "text": "A great glimpse into Peranakan culture and we thoroughly recommend a visit. The staff were extremely knowledgeable and answered all the questions we had surrounding the history of the house."
+        }
+      ],
+      "description": "NUS Baba House is a heritage house which exhibits the Straits Chinese material culture in a domestic context, providing the unique experience of visiting a Straits Chinese family home dating back to the early 20th century. It facilitates research and learning about the history, culture and evolution of the Peranakan community, as well as architectural traditions, urban changes and conservation efforts in Singapore. The gallery on the third floor hosts temporary exhibitions encouraging discourses on cultural encounters, hybridity and their contemporary implications in Singapore and beyond. - English Heritage Tours Tuesday – Friday, 10am - Mandarin Heritage Tour : First Monday of each month, 10am Self-guided Visit: Saturday, 1.30pm / 2.15pm / 3.15pm / 4pm",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d1857193-Reviews-NUS_Baba_House-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "157 Neil Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "088883",
+        "address_string": "157 Neil Road, Singapore 088883 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.27706",
+      "longitude": "103.83733",
+      "timezone": "Asia/Singapore",
+      "email": "babahouse@nus.edu.sg",
+      "phone": "+65 6227 5731",
+      "website": "http://babahouse.nus.edu.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d1857193-NUS_Baba_House-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#85 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "85"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "122",
+      "review_rating_count": {
+        "1": "0",
+        "2": "1",
+        "3": "7",
+        "4": "30",
+        "5": "84"
+      },
+      "photo_count": "49",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d1857193-m66827-Reviews-NUS_Baba_House-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1100"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1100"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1100"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1100"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1330"
+            },
+            "close": {
+              "day": 6,
+              "time": "1700"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: Closed",
+          "Tuesday: 10:00 - 11:00",
+          "Wednesday: 10:00 - 11:00",
+          "Thursday: 10:00 - 11:00",
+          "Friday: 10:00 - 11:00",
+          "Saturday: 13:30 - 17:00",
+          "Sunday: Closed"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Historic Sites",
+              "localized_name": "Historic Sites"
+            },
+            {
+              "name": "Architectural Buildings",
+              "localized_name": "Architectural Buildings"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622331",
+          "name": "Bukit Merah"
+        },
+        {
+          "location_id": "15622601",
+          "name": "Everton Park"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "3"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "33"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "31"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "17"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "17"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "157 Neil Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "088883",
+        "address_string": "157 Neil Road, Singapore 088883 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Hong San See Temple Singapore": [
+    {
+      "location_id": "2341795",
+      "name": "Singapore Hong San See",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/6b/02/84/singapore-hong-san-see.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/a7/42/db/17.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/26/2b/a2/09/al-tempio.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/26/2b/a4/95/tra-i-grattacieli-di.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/26/2b/a4/5b/il-drago.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Delightful ",
+          "text": "A gorgeous temple. Extremely pretty and ornate. We were given a bag with a lovely framed photo. Worth a visit.  It is Near Robertson’s quay. I would recommend a visi. "
+        },
+        {
+          "title": "Relatively Quiet",
+          "text": "The temple is located very close to the Fort Canning/Clarke Quay MRT stations, and despite being in a large urban area, it is not that crowded.  The two times I went, there were very few people there aside from a few worshipers.  The temple itself is not the most impressive temple in Singapore, but it is an interesting place to spend some time in looking around."
+        },
+        {
+          "title": "Treasure Hunt ",
+          "text": "Can you find them all?\n\n1. Heavenly Lantern: representing the Jade Emperor\n2. Guang Ze Zun Wang: the patron dirty of the temple sitting with his consort \n3. Dragon fish: carvings\n4. Phoenix guardians: inspired by the temple's name\n5. Water buffalo: statues\n6. Burners: for paper offerings to the deities \n7. Coulets: by the great Pan Shou\n8. A memorial: to the 31 pioneers who were moved from their resting place\n9. Odd stairway: with different numbers of steps on each side \n10. Flowers and birds: on rare columns \n11. Old stelle: from Mt Wallich \n12. Gong Huan: statues holding up and supporting the temple \n13. Marionette: statue of a deity\n14. Eight immortals: finely carved\n15. A poking tongue!\n\nIf you can't, ask Unlce."
+        },
+        {
+          "title": "Not the most stunning Chinese Temple I've seen but still rather nice.",
+          "text": "Having lived in Hong Kong and traveled extensively in Asia I have visited more than a few Chinese temples and whilst in Singapore I thought I'd take a look at Hong San See.  Erected by migrants from Fujian province of China over 100 years ago and dedicated as a National monument in 1978 Hong San See is a nice enough temple but certainly not the most stunning I've ever seen, whether it was going through some renovation I'm not sure but the exterior terrace in particular just seemed untidy and cluttered with 'stuff'.  The temple opens daily from 7am to 6pm, I was lucky as I got there at 6:30pm but the temple curator was just locking up and let me in for 10 minutes... What a very nice guy."
+        },
+        {
+          "title": "Planning to visit more",
+          "text": "Located at 30 Mohamed Sultan Road among rows of cafes and restaurants, this Nan Ann clan temple was built in 1836 by a Chinese migrant from Fukien province of China. It moved from its original site on Wallich Road to its present site. It is a symbol of how migrants, seeking better fortunes in foreign lands, can strike success and wealth on the back of industry and wisdom. Built in traditional Chinese architectural style, the temple boasts of rich decorations such as ornamental columns, granite plaques and magnificent prayer halls and is now a gazetted national monument, since 1978. I was almost shocked by how this historic building stands quietly among modern amenities and urban features of the River Valley area. It stands on a hilly position, accessible after a flight of stairs. The resident deity is Guangze Zun Wang. \nConstruction materials came from China, such as wood carvings and stone dragon columns. It has received several renovations over the years. in 2010, it received an Award of Excellence from the UNESCO. Columns are decorated very well; some features were unusual to my eyes. Beams of the ceiling contain information plaques and poetry. This place is stunningly beautiful, the architecture is simply magnificent and is open daily, closing exactly by 5pm (the friendly caretaker chatted about its history and later gave me a heads-up about closing time). It is permitted to take photos, of course keeping sensitivity to other devotees."
+        }
+      ],
+      "description": "Built between 1908 and 1913, the Hong San See temple, located along Mohamed Sultan Road, was originally located at Tras Street in Tanjong Pagar in 1829. Established by the Hokkien people of the Lam Ann clan, this temple is dedicated to Guang Ze Zun Wang, the God of Fortune. It later relocated to Mohamed Sultan road, and the temple now draws worshippers from different dialect groups.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2341795-Reviews-Singapore_Hong_San_See-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "31 Mohamed Sultan Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "238975",
+        "address_string": "31 Mohamed Sultan Road, Singapore 238975 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.29275",
+      "longitude": "103.84115",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6737 3683",
+      "website": "http://www.yoursingapore.com/content/traveller/en/browse/see-and-do/culture-and-heritage/places-of-worship/singapore-hong-san-see.html?TAHotelCode=122",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2341795-Singapore_Hong_San_See-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#364 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "364"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "17",
+      "review_rating_count": {
+        "1": "0",
+        "2": "0",
+        "3": "4",
+        "4": "9",
+        "5": "4"
+      },
+      "photo_count": "82",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2341795-m66827-Reviews-Singapore_Hong_San_See-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Sacred & Religious Sites",
+              "localized_name": "Sacred & Religious Sites"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622583",
+          "name": "Institution Hill"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622371",
+          "name": "River Valley"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "1"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "10"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "2"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "1"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "31 Mohamed Sultan Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "238975",
+        "address_string": "31 Mohamed Sultan Road, Singapore 238975 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Chinese Heritage Centre, Singapore": [
+    {
+      "location_id": "5031119",
+      "name": "Chinese Heritage Centre",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/6d/39/15/chinese-heritage-centre.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/04/b4/ba/0a/chinese-heritage-centre.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/18/f2/de/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/18/f2/c7/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/6d/39/57/chinese-heritage-centre.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Interesting and Informative",
+          "text": "This is well worth going into and very interesting.  There are different layouts of peoples' homes and workplaces showing how the Chinese people had to live and work in quite awful conditions and not that long ago either. Very well displayed and most informative. Spent a couple of hours here."
+        },
+        {
+          "title": "The Biggest Surprise in Chinatown",
+          "text": "If you want an historical look at the Chinese history in Singapore I recommend you visit the Chinese Heritage Centre in Chinatown.  This was an outstanding museum based in the old original building owed by a master tailor in the 1950's.  It was an all encompassing journey through time with the static displays augmented by a very good audio unit.  We were so engrossed in all the detail that we ended up spending over 2 hrs wandering up and down the three level building.  It was a journey well taken."
+        },
+        {
+          "title": "Good to visit if on NTU campus",
+          "text": "There are two exhibitions: Chinese More or Less and Nantah Pictorial Exhibition. The first one addresses themes about what it means to be Chinese, especially for overseas Chinese and those who have been abroad for several generations. These themes are similar to some of the exhibits in the Peranakan Museum. The Nantah Exhibition is mainly old photos of Nanyang University, later Nanyang Technological Institute, and finally the present-day Nanyang Technological University. It is interesting to see if you are a student or staff at NTU, but might not be so exciting for a general audience.\nI recommend 1 hr for a quick overview, or 2 hours if you like to read every plaque :)\nFree entry for NTU staff and students."
+        },
+        {
+          "title": "Wow! Memorable",
+          "text": "As the film “Crazy Rich Asians” draws attention to those who have lived in Singapore for generations, the Chinese Heritage Centre provides the backstory.  The tour of this house that was home to a tailor shop, a doctor’s office and about fifty people until the early 1960s shows their fortitude and resilience.  This was the highlight of our visit to Singapore."
+        },
+        {
+          "title": "An interest insight into the not so distant past",
+          "text": "We decided to visit the Chinese Heritage Centre during our recent visit to Singapore.  Our entry fee included an audio visual guide that was really useful for providing context throughout the tour. The centre has taken great effort to provide a realistic view of the way in which many Chinese people lived in the typical housing seen through Chinatown. From the tailor shop on the first floor to the tenanted cubicles rented out on the second floor it shined a light in the hardships of day to day living in Chinatown as relatively recently as the 1950s. \nThe Heritage Centre is close to the Chinatown MRT and is air conditioned."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d5031119-Reviews-Chinese_Heritage_Centre-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "12 Nanyang Dive, Nanyang Technological University",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "637721",
+        "address_string": "12 Nanyang Dive, Nanyang Technological University, Singapore 637721 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.3438",
+      "longitude": "103.68403",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6790 6176",
+      "website": "http://chc.ntu.edu.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d5031119-Chinese_Heritage_Centre-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#285 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "285"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "22",
+      "review_rating_count": {
+        "1": "0",
+        "2": "1",
+        "3": "0",
+        "4": "10",
+        "5": "11"
+      },
+      "photo_count": "50",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d5031119-m66827-Reviews-Chinese_Heritage_Centre-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622349",
+          "name": "Western Water Catchment"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "2"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "3"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "6"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "1"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "7"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "12 Nanyang Dive, Nanyang Technological University",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "637721",
+        "address_string": "12 Nanyang Dive, Nanyang Technological University, Singapore 637721 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Kampong Glam & Malay Culture in Singapore": [
+    {
+      "location_id": "15201256",
+      "name": "Singapore Visitor Centre @ CUBE - Boutique Capsule Hotel (Kampong Glam)",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/15/01/03/b8/exterior-view-of-singapore.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/15/01/03/ae/exterior-view-of-singapore.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/15/01/03/ab/singapore-visitor-centre.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/15/01/03/aa/singapore-visitor-centre.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Better visit another Visitor Centre.",
+          "text": "Very helpful assistant present but other than a map of Singapore and a Big Bus schedule, there was no other literature available."
+        }
+      ],
+      "description": "Services & Facilities Available: - Tourist Enquiries - Sale of Attraction Tickets - Hotel Reservation - Purchase connectivity solutions (Wi-Fi devices) Cultural Events conducted every Friday, Saturday & Sunday.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d15201256-Reviews-Singapore_Visitor_Centre_CUBE_Boutique_Capsule_Hotel_Kampong_Glam-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "55 Bussorah Street",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "199471",
+        "address_string": "55 Bussorah Street, Singapore 199471 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.3017",
+      "longitude": "103.85942",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6291 7386",
+      "website": "http://www.visitsingapore.com/travel-guide-tips/getting-around/tourism-centre/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d15201256-Singapore_Visitor_Centre_CUBE_Boutique_Capsule_Hotel_Kampong_Glam-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#936 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "936"
+      },
+      "rating": "3.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.0-66827-5.svg",
+      "num_reviews": "1",
+      "review_rating_count": {
+        "1": "0",
+        "2": "0",
+        "3": "1",
+        "4": "0",
+        "5": "0"
+      },
+      "photo_count": "4",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d15201256-m66827-Reviews-Singapore_Visitor_Centre_CUBE_Boutique_Capsule_Hotel_Kampong_Glam-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0800"
+            },
+            "close": {
+              "day": 1,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0800"
+            },
+            "close": {
+              "day": 2,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0800"
+            },
+            "close": {
+              "day": 3,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0800"
+            },
+            "close": {
+              "day": 4,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0800"
+            },
+            "close": {
+              "day": 5,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0800"
+            },
+            "close": {
+              "day": 6,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0800"
+            },
+            "close": {
+              "day": 7,
+              "time": "1800"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 08:00 - 18:00",
+          "Tuesday: 08:00 - 18:00",
+          "Wednesday: 08:00 - 18:00",
+          "Thursday: 08:00 - 18:00",
+          "Friday: 08:00 - 18:00",
+          "Saturday: 08:00 - 18:00",
+          "Sunday: 08:00 - 18:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "traveler_resources",
+          "localized_name": "Traveler Resources"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Traveler Resources",
+          "localized_name": "Traveler Resources",
+          "categories": [
+            {
+              "name": "Visitor Centers",
+              "localized_name": "Visitor Centers"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291617",
+          "name": "Kampong Glam"
+        },
+        {
+          "location_id": "15622680",
+          "name": "Arab Street"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "1"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "0"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "0"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "0"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "55 Bussorah Street",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "199471",
+        "address_string": "55 Bussorah Street, Singapore 199471 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Contemporary Arts Center": [
+    {
+      "location_id": "8738861",
+      "name": "NTU Centre for Contemporary Art",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/ec/57/10/incomplete-urbanism-attempts.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0c/f0/74/86/ntu-centre-for-contemporary.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/ec/57/f0/exhibition-de-tour-with.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/ec/57/de/workshop-for-students.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/ec/57/ab/tomas-saraceno-arachnid.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Amazing place",
+          "text": "This center has a lot of art galleries with excellent original artworks, both Asian and Western styles. You can also visit some interesting exhibitions that are well organized."
+        },
+        {
+          "title": "great overview of contemporary art scene",
+          "text": "if you are interested in art, visiting CCA in Singapore is a must; they have an official exhibition space with a good agenda, they offer residences for artists, but what is really great is the fact that this space gets together several well reputed independent art galleries, each with her own exhibitions; all the staff we encountered were very friendly and we learned a lot about the art scene in the area; prices are reasonable and a good part of the works we have seen have good quality; enjoy your day at CCA !"
+        }
+      ],
+      "description": "Located in Gillman Barracks, the NTU Centre for Contemporary Art Singapore (NTU CCA Singapore) is a national research centre of Nanyang Technological University and is supported by a grant from the Economic Development Board, Singapore. The Centre is unique in its threefold constellation of research & academic programmes, international exhibitions, and residencies, positioning itself as a space for critical discourse and diverse forms of knowledge production.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d8738861-Reviews-NTU_Centre_for_Contemporary_Art-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Blk 43 Malan Road Gillman Barracks",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "109443",
+        "address_string": "Blk 43 Malan Road Gillman Barracks, Singapore 109443 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.27455",
+      "longitude": "103.8042",
+      "timezone": "Asia/Singapore",
+      "email": "ntuccaexhibitions@ntu.edu.sg",
+      "phone": "+65 6339 6503",
+      "website": "http://ntu.ccasingapore.org/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d8738861-NTU_Centre_for_Contemporary_Art-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#669 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "669"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "3",
+      "review_rating_count": {
+        "1": "0",
+        "2": "0",
+        "3": "0",
+        "4": "1",
+        "5": "2"
+      },
+      "photo_count": "28",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d8738861-m66827-Reviews-NTU_Centre_for_Contemporary_Art-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 2,
+              "time": "1200"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1200"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1200"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1200"
+            },
+            "close": {
+              "day": 5,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1200"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1200"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: Closed",
+          "Tuesday: 12:00 - 19:00",
+          "Wednesday: 12:00 - 19:00",
+          "Thursday: 12:00 - 19:00",
+          "Friday: 12:00 - 21:00",
+          "Saturday: 12:00 - 19:00",
+          "Sunday: 12:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "shopping",
+          "localized_name": "Shopping"
+        },
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Shopping",
+          "localized_name": "Shopping",
+          "categories": [
+            {
+              "name": "Art Galleries",
+              "localized_name": "Art Galleries"
+            }
+          ]
+        },
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Art Galleries",
+              "localized_name": "Art Galleries"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622606",
+          "name": "Telok Blangah Drive"
+        },
+        {
+          "location_id": "15622331",
+          "name": "Bukit Merah"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "1"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "1"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "0"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "1"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "Blk 43 Malan Road Gillman Barracks",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "109443",
+        "address_string": "Blk 43 Malan Road Gillman Barracks, Singapore 109443 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "The Substation, Singapore Contemporary Art Centre": [
+    {
+      "location_id": "2344510",
+      "name": "Timbre X @ The Substation",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/14/f3/c3/a6/img-20180505-183727-largejpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-p/09/c3/70/7c/timbre-the-substation.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-o/1c/ee/04/52/dear-timbre-music-square.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/0d/75/f3/img-20180214-232756-largejpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0d/45/bf/99/timbre-the-substation.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "WORST place to go in singapore! DIRTY !",
+          "text": "Avoid at all cost! EXPENSIVE and dirty! The company boss is an arrogant MP ! worst service ever! DO NOT GO! you are warned!!"
+        },
+        {
+          "title": "Fake News",
+          "text": "Talked up as a go to destination, but lacks authenticity.  Rickety old chairs and tables sited in builders pit. Order your own food and drink, which is thrown at you by waiters in a hurry without any plates or cutlery. Queue for a gritty old toilet and then as an exit prize, 10% service charge + a guest fee!  The live band (Supersonic) were decent but could do with more songs and less chat - 30 min sessions with maybe 15mins of music."
+        },
+        {
+          "title": "Horrible service",
+          "text": "Went with a group of friends, this has to be the worst service that I have ever seen in Singapore. Staff is rude and drinks are terrible. They must be using the lowest quality possible of drinks available in the market. It's a petty because the band was great. I would have stay longer if it wasn't for the service."
+        },
+        {
+          "title": "Birthday at Timbre ",
+          "text": "The worst service ever ! I never experienced in Singapore a bar where the staffs are extremely rude !!! The bar, food and band are amazing but you feel very disrespected by the staffs . "
+        },
+        {
+          "title": "Best pizza we've had in Singapore",
+          "text": "I ordered only the duck pizza, and it was take away.  My children and I heard positive reviews of their duck pizza and my mission was to hunt it down and bring it back to our room.  We were not disappointed.  The sauce was a good mix of sweet and pizza.  The crispy topping adding an extra level of taste and texture.  The service was good and the pizza came out very quickly.  The restaurant looks like it would be fun but I had hungry teenagers waiting for food."
+        }
+      ],
+      "description": "Away from the crowd and hidden at the back of The Substation, the flagship Timbre X live music venue emits an exclusive old school casual charm. Amongst the waving leafy fronds, dine alfresco, quench your thirst at the bar and enjoy nightly life music performances by Singapore’s homegrown talents. With an upgraded stage, sound and lights system, resident bands 53A and SuperSonic continue to be the forefront of live music scene in Singapore. Music lovers get pumped up on Friday and Saturday with party-anthem repertoire at Garden Live, catch 53A on Fridays and SuperSonic on Saturday evenings. Both nights are devoted to getting customer off their seats and onto the dance floor!",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2344510-Reviews-Timbre_X_The_Substation-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "45 Armenian Street The Substation Garden",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179936",
+        "address_string": "45 Armenian Street The Substation Garden, Singapore 179936 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.294676",
+      "longitude": "103.849266",
+      "timezone": "Asia/Singapore",
+      "email": "info@timbregroup.asia",
+      "phone": "+65 6338 8030",
+      "website": "http://www.timbregroup.asia/timbresg/main.asp",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2344510-Timbre_X_The_Substation-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#81 of 196 Nightlife in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "196",
+        "ranking": "81"
+      },
+      "rating": "3.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.0-66827-5.svg",
+      "num_reviews": "42",
+      "review_rating_count": {
+        "1": "8",
+        "2": "8",
+        "3": "5",
+        "4": "12",
+        "5": "9"
+      },
+      "photo_count": "15",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2344510-m66827-Reviews-Timbre_X_The_Substation-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 2,
+              "time": "1500"
+            },
+            "close": {
+              "day": 2,
+              "time": "2300"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1500"
+            },
+            "close": {
+              "day": 3,
+              "time": "2300"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1500"
+            },
+            "close": {
+              "day": 4,
+              "time": "2300"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1500"
+            },
+            "close": {
+              "day": 5,
+              "time": "2300"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1800"
+            },
+            "close": {
+              "day": 6,
+              "time": "2300"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1700"
+            },
+            "close": {
+              "day": 7,
+              "time": "2300"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: Closed",
+          "Tuesday: 15:00 - 23:00",
+          "Wednesday: 15:00 - 23:00",
+          "Thursday: 15:00 - 23:00",
+          "Friday: 15:00 - 23:00",
+          "Saturday: 18:00 - 23:00",
+          "Sunday: 17:00 - 23:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nightlife",
+          "localized_name": "Nightlife"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nightlife",
+          "localized_name": "Nightlife",
+          "categories": [
+            {
+              "name": "Bars & Clubs",
+              "localized_name": "Bars & Clubs"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622372",
+          "name": "Museum"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        },
+        {
+          "location_id": "15622424",
+          "name": "Bras Basah"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "2"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "6"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "1"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "1"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "25"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "45 Armenian Street The Substation Garden",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179936",
+        "address_string": "45 Armenian Street The Substation Garden, Singapore 179936 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Red Dot Design Museum, Singapore": [
+    {
+      "location_id": "1937005",
+      "name": "Red Dot Design Museum",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/16/f6/30/red-dot-design-museum.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/04/9f/8f/a7/design-museum-shop.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/ed/1f/dc/red-dot-design-museum.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/2d/60/fe/red-dot-design-museum.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/ed/20/70/many-red-dot-award-winning.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Must See for lovers of clever design !",
+          "text": "If you are interested in design - graphic design, interior design, industrial design etc you will LOVE this place.  I spent 4 hours looking through the displays of Red Dot Design winners and was thoroughly captivated.  This was absolutely the best value outing of our entire stay in Singapore.  Everything in Singapore is so expensive - at $12 a ticket this is an awesome outing."
+        },
+        {
+          "title": "Red Dot Design Museum",
+          "text": "Saw this as place to go in a guide of Singapore. Not much advertising but we made the effort to go and see. We were pleased to have seen such an interesting show case of innovative ideas and talent.\nWe spend over an hour in the two storey building reading each exhibition and looking at the processes that went into their creation.\nIf you have a kid doing Design and Tech or similar in high school take them."
+        },
+        {
+          "title": "Interesting Exhibition on Modern Product Design",
+          "text": "Given the cheap cost of entry I would say this museum is well worth the visit. When we visited they were displaying modern products attempting to solve future problems.\n\nMany good product designs were on display, some applying to difficult and important problems. Others targeting first world problems or straight up fads.\n\nOverall it was an interesting selection of products giving some insight into design problems and solutions that you can see everywhere around you if you're looking."
+        }
+      ],
+      "description": "A boutique museum along the Waterfront Promenade at the Marina Bay. Red Dot Design Museum is the physical embodiment of the international Red Dot Design Award. Learn and enjoy good design from one of the most prestigious design awards in the world, through works from across disciplines including innovative products, research concepts, communication works and art.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d1937005-Reviews-Red_Dot_Design_Museum-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "11 Marina Boulevard Red Dot Design Museum",
+        "street2": "Red Dot Design Museum",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018940",
+        "address_string": "11 Marina Boulevard Red Dot Design Museum Red Dot Design Museum, Singapore 018940 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.280222",
+      "longitude": "103.85633",
+      "timezone": "Asia/Singapore",
+      "email": "museum@red-dot.sg",
+      "phone": "+65 6514 0111",
+      "website": "http://www.museum.red-dot.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d1937005-Red_Dot_Design_Museum-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#185 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "185"
+      },
+      "rating": "3.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.5-66827-5.svg",
+      "num_reviews": "261",
+      "review_rating_count": {
+        "1": "11",
+        "2": "26",
+        "3": "61",
+        "4": "95",
+        "5": "68"
+      },
+      "photo_count": "274",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d1937005-m66827-Reviews-Red_Dot_Design_Museum-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1100"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1100"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1100"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1100"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1100"
+            },
+            "close": {
+              "day": 5,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 11:00 - 19:00",
+          "Tuesday: 11:00 - 19:00",
+          "Wednesday: 11:00 - 19:00",
+          "Thursday: 11:00 - 19:00",
+          "Friday: 11:00 - 19:00",
+          "Saturday: 10:00 - 19:00",
+          "Sunday: 10:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            }
+          ]
+        },
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Specialty Museums",
+              "localized_name": "Specialty Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622528",
+          "name": "Bayfront"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "7"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "60"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "53"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "38"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "47"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "11 Marina Boulevard Red Dot Design Museum",
+        "street2": "Red Dot Design Museum",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018940",
+        "address_string": "11 Marina Boulevard Red Dot Design Museum Red Dot Design Museum, Singapore 018940 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Singapore Art Museum": [
+    {
+      "location_id": "310899",
+      "name": "Singapore Art Museum",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/47/24/14/singapore-art-museum.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/5a/3f/b8/installation-of-michael.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/5a/3f/b6/installation-of-hazel.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/5a/3f/ac/mural-on-the-facade-of.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/5a/3f/ab/installation-view-of.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Brow high curation",
+          "text": "Singapore Art Museum, Tanjung Pagar Districtpark: This popped up on our radar as we cycled to Sentosa and what a squeal of a find! SAM is local art lovers’ paradise and even though SAM at Bras Bash has since shuttered, it has a new address in the old buildings facing PSA. Covering an area on the first and third floor, staff are extremely sweet and the art standards always brow high. #eatstylishtravelstylish"
+        },
+        {
+          "title": "Outstanding use of the space…",
+          "text": "…and some amazing things to see AND do! First off, the LEGO city which all visitors can contribute to is one of the very best museum features I have ever seen, it’s amazing and the current main show by a Danish artist is pretty wonderful too, particularly the water vapour projection room. Definitely worth visiting, somewhere very different from the usual SG tourist spots as well."
+        },
+        {
+          "title": "Nice experience",
+          "text": "First time visiting. Came with friends.Nice place to be, seen the amazing artworks on display.  Definately will be back for more !"
+        },
+        {
+          "title": "A must go whilst in Singapore",
+          "text": "Absolutely love this place! I recommend anyone who is in Singapore to go and visit. Wonderful curated artwork which was great to get to know some of the very talented local artists. I love the artworks of Sarah Choo Jing! Cant wait to be back"
+        },
+        {
+          "title": "Wall Mural reflecting our history and nature",
+          "text": "Singapore Art Museum’s buildings were once home to Catholic boys' schools – St. Joseph’s Institution on Bras Basah Road and Catholic High School on Queen Street.\nBoth are presently closed for renovation.\nHowever, outside the Singapore Art Museum at 8Q (the former Catholic High School), there is a site-specific large mural by artists, Darel Seow and Lee Xin Li.\nThis mural is titled An Unnatural History.  This mural combines Darel Seow’s passion for natural history and storytelling, and Lee Xin Li’s interest in heritage and architecture. \nThere is a \"An Unnatural History\" website, where one take a step back into history and see which of these storied landmarks can be identified as well as the 168 species of animals on the murals.  \nSadly this mural was only for a temporary period until 6 June."
+        }
+      ],
+      "description": "Singapore Art Museum opened in 1996 as the first art museum in Singapore. Also known as SAM, the museum presents contemporary art from a Southeast Asian perspective for artists, art lovers and the art curious in multiple venues across the island, including a new anchor venue in the historic port area of Tanjong Pagar. SAM’s space at Tanjong Pagar Distripark houses expansive galleries for bold art presentations, a coffee bookshop by the port, and versatile spaces for programmes and collaborations. SAM is building one of the world's most important public collections of Southeast Asian contemporary art, with the aim of connecting the art and the artists to the public and future generations through exhibitions, programmes, and meaningful encounters with contemporary art.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d310899-Reviews-Singapore_Art_Museum-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "39 Keppel Rd",
+        "street2": "#01-02 Tanjong Pagar Distripark",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "089065",
+        "address_string": "39 Keppel Rd #01-02 Tanjong Pagar Distripark, Singapore 089065 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.271957",
+      "longitude": "103.836754",
+      "timezone": "Asia/Singapore",
+      "email": "enquiries@singaporeartmuseum.sg",
+      "phone": "+65 6697 9730",
+      "website": "http://www.singaporeartmuseum.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d310899-Singapore_Art_Museum-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#104 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "104"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "519",
+      "review_rating_count": {
+        "1": "26",
+        "2": "27",
+        "3": "101",
+        "4": "183",
+        "5": "182"
+      },
+      "photo_count": "519",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d310899-m66827-Reviews-Singapore_Art_Museum-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 19:00",
+          "Tuesday: 10:00 - 19:00",
+          "Wednesday: 10:00 - 19:00",
+          "Thursday: 10:00 - 19:00",
+          "Friday: 10:00 - 19:00",
+          "Saturday: 10:00 - 19:00",
+          "Sunday: 10:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Art Museums",
+              "localized_name": "Art Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622372",
+          "name": "Museum"
+        },
+        {
+          "location_id": "15622424",
+          "name": "Bras Basah"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "10"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "108"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "113"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "68"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "82"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "39 Keppel Rd",
+        "street2": "#01-02 Tanjong Pagar Distripark",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "089065",
+        "address_string": "39 Keppel Rd #01-02 Tanjong Pagar Distripark, Singapore 089065 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Esplanade Theatres on the Bay": [
+    {
+      "location_id": "324752",
+      "name": "Esplanade - Theatres on the Bay",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/18/60/8d/7b/photo5jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/2a/9b/0c/esplanade-theatres-on.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/2a/9c/1e/esplanade-theatres-on.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/2a/9b/cb/esplanade-theatres-on.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/2a/9b/bf/esplanade-theatres-on.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Nice",
+          "text": "The architecture itself is eye candy! The theatres are vibrant, with plenty of shows, restaurants and views of the waterfront."
+        },
+        {
+          "title": "esplanade",
+          "text": "Stopped by here after getting caught in a summer thunderstorm, and ended up catching some talented aerial artists performing!"
+        },
+        {
+          "title": "Great concert experience ",
+          "text": "The sound system and acoustics of Esplanade concert hall were impeccable.\n\nThe seats were pretty comfotable, and the ushers were very proficient"
+        },
+        {
+          "title": "Theatre shows",
+          "text": "It's a place to watch shows and with food outlets. You can also just sit outside and admire the views at night. Walk from there across the bridge to the Merlion Park."
+        },
+        {
+          "title": "Thank you for changing my mind:)",
+          "text": "Walking from Promenade, I saw Esplanade \nI was craving for coconut, but I only saw peanut \nI walked further into Esplanade, and my favourite now is durian :)"
+        }
+      ],
+      "description": "Affectionately known among locals as the \"durian\", Esplanade is one of the busiest arts centres in the world with about 3,000 performances presented yearly. Spot our prickly cladding in the middle of the central arts and cultural district, and take in the view from the Marina bay waterfront where our Outdoor Theatre is situated. Coming to Esplanade means that you're in for a complete lifestyle experience, from enjoying a night out at a show, to shopping and dining. And whether you're a first-timer, an ardent patron or fellow arts lover, you're most welcome here and we'll do our best to give you a great experience with the arts.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d324752-Reviews-Esplanade_Theatres_on_the_Bay-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 Esplanade Drive",
+        "street2": "Floor 1, Esplanade Mall",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "038981",
+        "address_string": "1 Esplanade Drive Floor 1, Esplanade Mall, Singapore 038981 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.28989",
+      "longitude": "103.85517",
+      "timezone": "Asia/Singapore",
+      "email": "mall@esplanade.com",
+      "phone": "+65 6828 8377",
+      "website": "https://www.esplanade.com/whats-on/category?GenreNames=Theatre",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d324752-Esplanade_Theatres_on_the_Bay-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#32 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "32"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "1097",
+      "review_rating_count": {
+        "1": "3",
+        "2": "4",
+        "3": "86",
+        "4": "456",
+        "5": "548"
+      },
+      "photo_count": "780",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d324752-m66827-Reviews-Esplanade_Theatres_on_the_Bay-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "theater_concerts",
+          "localized_name": "Concerts & Shows"
+        },
+        {
+          "name": "activities",
+          "localized_name": "Activities"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            }
+          ]
+        },
+        {
+          "name": "Concerts & Shows",
+          "localized_name": "Concerts & Shows",
+          "categories": [
+            {
+              "name": "Theaters",
+              "localized_name": "Theaters"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622655",
+          "name": "Marina Centre"
+        },
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "41"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "263"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "140"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "220"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "205"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "1 Esplanade Drive",
+        "street2": "Floor 1, Esplanade Mall",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "038981",
+        "address_string": "1 Esplanade Drive Floor 1, Esplanade Mall, Singapore 038981 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "National Design Centre, Singapore": [
+    {
+      "location_id": "5943805",
+      "name": "National Design Centre",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0d/fa/7c/a4/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/05/ed/a0/0a/national-design-center.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/05/30/15/e0/getlstd-property-photo.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/05/ed/a0/17/national-design-center.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/05/ed/a0/14/national-design-center.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "NDA",
+          "text": "I visited this with my friend father who was retired. It is in kadakwasala which is 20kms from Pune and the training is done here"
+        },
+        {
+          "title": "Somewhat disappointing ",
+          "text": "After reading write-up and publicity on 50 Years of Singapore Design, was expecting more from this particular exhibition but was somewhat disappointed by the crammed layput which didn't give prominence to outstanding features in the design of iconic brand names eg Singapore Girl costume/Haw Par Brothers Tiger Balm. They were part of linear displays on the wall together with other less outstanding items. Granted they were created by advertising agencies and not too many trade secrets should be given away but how did they come by that striking paper covering of that Tiger Balm container, the particular colors used for eg seeing that it's so distinctive that it's not been changed for years?\nOne piece though was memorable and well-presented, the plastic Kopitiam chair where it's explained that every part is purposefully designed, the hole in the centre for easy lifting up and chaining chairs together at closing time, congratulations on curating that piece, exactly what a viewer wants to see and understand about a particular design!\nPerhaps an attendant could be stationed in the hall as one large group of inconsiderate viewers were talking and laughing loudly, treating the venue as their place of socialisation while other visitors were trying to concentrate on the exhibits. \nNot a security guard in sight except behind the desk at the main entrance! \n"
+        },
+        {
+          "title": "Celebrating Design in a Designed Nation",
+          "text": "Singapore is an \"intentional community\" ⸺ a place designed with a purpose ⸺ growing with confidence in its ability to create social and economic value. Fitting, then, that it should dedicate a National Centre to Design in a decade when the discipline has become recognised as including, but also being much more than, the craft of artisans. Across schools, workplaces and government,  Singapore has taken \"Design Thinking\" to heart, teaching it as a key to transforming national and corporate strategy into innovation and positive change. \n\nIn the first decades of nation building, when rapid economic growth was seen as the priority, art,  design and creativity was not emphasised as a national priority. Today, however, Singapore's National Design Centre sits at the heart of a new creative quarter whose students and practitioners will intentionally shape the products, services,  experiences and businesses of tomorrow.  Seen that way, the National Design Centre is becoming more than an excellent exhibition venue and a great place for coffee or a creative meeting with friends and colleagues. It's also a gathering place for those who want to apply creativity to create different dimensions of value for this island nation's future. Well worth a visit. "
+        },
+        {
+          "title": "Nice installation ",
+          "text": "I visited the Centre to attend a conference welcome reception. The canapés were very nice and served by attentive and professional staff. However, the acoustics do not lend themselves to large crowds in that it was difficult to hear conversations. I really liked the installations featuring aspects of outstanding design. There was no entrance fees. Nice!"
+        },
+        {
+          "title": "WORTH A VISIT IF YOU HAVE THE TIME.",
+          "text": "I have been here on a number of occasions over the past few years.\nWhilst I enjoy the exhibits- I'm a little disappointed with the lack of new items. The café and retail section is cool."
+        }
+      ],
+      "description": "The National Design Centre (NDC) is the nexus for all things design. This is where designers and businesses congregate to exchange ideas, conduct business, use its facilities and obtain assistance from the national agency for design, the DesignSingapore Council. Centrally located in the arts, cultural, learning and entertainment district in the Bras Basah-Bugis area, it is well placed to invite the public to learn about design through its exhibitions and programmes.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d5943805-Reviews-National_Design_Centre-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "111 Middle Road National Design Centre",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "188969",
+        "address_string": "111 Middle Road National Design Centre, Singapore 188969 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.298726",
+      "longitude": "103.85362",
+      "timezone": "Asia/Singapore",
+      "website": "http://designsingapore.org/national-design-centre/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d5943805-National_Design_Centre-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#293 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "293"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "34",
+      "review_rating_count": {
+        "1": "0",
+        "2": "2",
+        "3": "9",
+        "4": "11",
+        "5": "12"
+      },
+      "photo_count": "106",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d5943805-m66827-Reviews-National_Design_Centre-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0900"
+            },
+            "close": {
+              "day": 1,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0900"
+            },
+            "close": {
+              "day": 2,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0900"
+            },
+            "close": {
+              "day": 3,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0900"
+            },
+            "close": {
+              "day": 4,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0900"
+            },
+            "close": {
+              "day": 5,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0900"
+            },
+            "close": {
+              "day": 6,
+              "time": "2100"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0900"
+            },
+            "close": {
+              "day": 7,
+              "time": "2100"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 09:00 - 21:00",
+          "Tuesday: 09:00 - 21:00",
+          "Wednesday: 09:00 - 21:00",
+          "Thursday: 09:00 - 21:00",
+          "Friday: 09:00 - 21:00",
+          "Saturday: 09:00 - 21:00",
+          "Sunday: 09:00 - 21:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Specialty Museums",
+              "localized_name": "Specialty Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622525",
+          "name": "Victoria"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "3"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "6"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "8"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "5"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "8"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "111 Middle Road National Design Centre",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "188969",
+        "address_string": "111 Middle Road National Design Centre, Singapore 188969 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Victoria Theatre Singapore": [
+    {
+      "location_id": "446443",
+      "name": "Victoria Theatre & Victoria Concert Hall",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0b/6a/01/68/victoria-theatre-and.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0b/6a/01/67/victoria-theatre-and.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0b/6a/01/6a/inside-victoria-theatre.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0b/6a/01/69/inside-victoria-concert.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0b/69/fa/6e/the-atrium.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Beautiful",
+          "text": "Beautiful building which is a dazzling white. We didn't go inside but it is well worth visiting. Wonderful ornate clock tower in the middle off the building too"
+        },
+        {
+          "title": "Home of the Singapore Symphony Orchestra",
+          "text": "Victoria Theatre & Victoria Concert Hall is a very stately and elegant historical building with a British colonial clock tower. Magnificent architecture."
+        },
+        {
+          "title": "Concert: Seika Ishida Plays Mozart",
+          "text": "The concert hall that I went to was situated on the second floor of a glamorous looking two/three story building. Compared to the Esplanade Concert Hall, it is sizeably smaller, but definitely provides a much less crowded and more cozy music listening experience."
+        },
+        {
+          "title": "Positive Aspects",
+          "text": "This historical builiding is located within the central business district. It is well maintained. The ambience is quiet and serene."
+        },
+        {
+          "title": "One of a kind experience",
+          "text": "A stone's throw away from City Hall MRT, behind Parliament House. \nIconic and majestic, guarded by Sir Stamford Raffles Statue \nInterior elegant and quaint \nConcert Hall impressive and ideal to host musicals \nGreat to explore, away from the busy City Hall vicinity"
+        }
+      ],
+      "description": "The grand old dames of Singapore’s performing arts scene, Victoria Theatre and Victoria Concert Hall (VTVCH), returns after a three-year refurbishment to Singapore's growing arts and cultural landscape. Its elegant Victorian facade is well-preserved, so are its famed clock tower and original passageway connecting the theatre and concert hall. Walk through this charming building to see its heritage elements carefully conserved, namely its 152-year-old twin domes. Providing mid-sized performance venues, VTVCH fills a gap in the local arts scene, and now has improved acoustics, music and dance rehearsal rooms and state-of-the-art facilities.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d446443-Reviews-Victoria_Theatre_Victoria_Concert_Hall-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "9 Empress Place Victoria Theatre",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179558",
+        "address_string": "9 Empress Place Victoria Theatre, Singapore 179558 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.288621",
+      "longitude": "103.85146",
+      "timezone": "Asia/Singapore",
+      "email": "ssophie@vtvch.com",
+      "phone": "+65 6908 8810",
+      "website": "http://www.vtvch.com",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d446443-Victoria_Theatre_Victoria_Concert_Hall-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#114 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "114"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "105",
+      "review_rating_count": {
+        "1": "0",
+        "2": "0",
+        "3": "13",
+        "4": "56",
+        "5": "36"
+      },
+      "photo_count": "198",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d446443-m66827-Reviews-Victoria_Theatre_Victoria_Concert_Hall-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "theater_concerts",
+          "localized_name": "Concerts & Shows"
+        },
+        {
+          "name": "activities",
+          "localized_name": "Activities"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            }
+          ]
+        },
+        {
+          "name": "Concerts & Shows",
+          "localized_name": "Concerts & Shows",
+          "categories": [
+            {
+              "name": "Theaters",
+              "localized_name": "Theaters"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622412",
+          "name": "City Hall"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "2"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "19"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "23"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "24"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "18"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "9 Empress Place Victoria Theatre",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179558",
+        "address_string": "9 Empress Place Victoria Theatre, Singapore 179558 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "NUS University Museum, Singapore": [
+    {
+      "location_id": "2341734",
+      "name": "NUS Museum",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0d/fc/86/f3/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0d/fc/86/2a/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/25/3e/49/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/25/3e/48/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/25/3e/47/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "An under rated place that might interests the discerning…",
+          "text": "This small museum is free entrance to the public and for anyone who is interested in Chinese artefacts this is a good introductory place to visit.\n\nWhilst the collections are not extensive, I found it very enjoyable to whilst away a few hours. If you come close to meal time (lunch) - take a walk across to the NUS U town and there you can find cheap to not so cheap food to enjoy. From locals favourite like chicken rice to MALA noodles.\n\nBack to the Museum: there are various types of porcelains from different dynasties and also if you are interested in Chinese paintings and calligraphy, there is a small collection. This is one of the few places in SG where it is free entrance and it is air conditioned!\n\nThe nearest train station is either Kent Ridge or Clementi MRT station. There should be shuttle service into NUS that goes to U town. From there you can walk around 5-10 mins walk to the museum."
+        },
+        {
+          "title": "Very Nice Collection",
+          "text": "The National University of Singapore has a very nice collection of Chinese and Malay art.  Additionally, it seems there is always at least 1 rotating exhibit, more during the school year.  It is not large and depending on how much work is on view, can be enjoyed in about 1.5 hours.  The Chinese Ink Works and the Resource Gallery are a must see.  The collection has an academic feel which is quite nice in the hustle bustle of Singapore.  The architecture around the campus here is definitely also worth a look."
+        },
+        {
+          "title": "Museum Visit",
+          "text": "Located in NUS compound.easily accessible by NUS shuttle bus.Admission Free for all.Greeted by Harry. Well kept collections and educational exhibition."
+        },
+        {
+          "title": "A gem of an academic museum",
+          "text": "A lovely academic museum - i.e., with a focus on the art history of the region and exhibit curation. We saw three very interesting exhibits, but I would say only one of which was geared towards the \"general public\"; the other two were more appropriate for artists / art historians, although there certainly interesting material even for the casual browser.\n\nTake the MRT to Kent Ridge, come out in front of the hospital and take the free campus A2 shuttle to the museum (the driver will help you)."
+        },
+        {
+          "title": "Why call it NUS Museum?",
+          "text": "The positive points of NUS Museum are (1) it's free, (2) beautiful building & interior (3) nice collection of arts, ceramics and, (4) just across from Lee Kong Chian Natural History Museum so you can do both in a single half-day with time to spare. \nNow for my main grouse - why is the 'NUS Museum' not about the history of National University of Singapore? NUS has a rich history from its inception as University of Malaya in 1949 after merging of King Edward VII College of Medicine and Raffles College. After the Separation of Malaysia and Singapore, UM was dichotomised into University of Malaya (in Kuala Lumpur) and University of Singapore which subsequently became NUS.  \nThe history of NUS is intertwined with the history of Singapore from the time of British colonial rule to WWII, to the tumultuous period before independence and to the modern period with important contributions to the nation's growth. \n\nThis is the story of NUS. \n\nThe arts exhibition should be moved to the National Arts Gallery (that's just my personal opinion) and this \"NUS Museum\" should rightly focus on the history of NUS."
+        }
+      ],
+      "description": "The NUS Art Museum aims to create an enriching experience of the social history and the art of Asia to NUS and the nation through strategic acquisitions, exhibitions and research of an extensive range of artworks.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2341734-Reviews-NUS_Museum-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "University Cultural Centre National University of Singapore 50 Kent Ridge Crescent",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "119279",
+        "address_string": "University Cultural Centre National University of Singapore 50 Kent Ridge Crescent, Singapore 119279 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.30176",
+      "longitude": "103.77212",
+      "timezone": "Asia/Singapore",
+      "website": "http://www.yoursingapore.com/content/traveller/en/browse/see-and-do/arts-and-entertainment/art/nus-museum.html?TAHotelCode=22",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2341734-NUS_Museum-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#473 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "473"
+      },
+      "rating": "3.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.5-66827-5.svg",
+      "num_reviews": "13",
+      "review_rating_count": {
+        "1": "1",
+        "2": "0",
+        "3": "2",
+        "4": "9",
+        "5": "1"
+      },
+      "photo_count": "17",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2341734-m66827-Reviews-NUS_Museum-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Specialty Museums",
+              "localized_name": "Specialty Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622540",
+          "name": "National University of Singapore"
+        },
+        {
+          "location_id": "15622357",
+          "name": "Queenstown"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "5"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "6"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "0"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "1"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "University Cultural Centre National University of Singapore 50 Kent Ridge Crescent",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "119279",
+        "address_string": "University Cultural Centre National University of Singapore 50 Kent Ridge Crescent, Singapore 119279 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Sun Yat Sen Memorial Hall": [
+    {
+      "location_id": "338367",
+      "name": "Sun Yat Sen Nanyang Memorial Hall",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/03/ea/f3/6e/sun-yat-sen-nanyang-memorial.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/8e/27/27/the-complex.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/33/7c/45/dr-sun-yat-sen.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/25/b3/d9/bf/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/25/b3/d9/44/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A nice museum with a garden of greenery!",
+          "text": "As I have resumed my cultural and historical walking trail, my first in 2023, I am starting in Balestier and visited this memorial hall of Dr Sun Yat Sen, the founding Father of modern China! He is one of my most respected and adored \"idols\".\n\nIt has been about 7 years since my last visit here - Sun Yat Sen Nanyang Memorial Hall (孙中山南洋纪念馆，又称晚晴园). \n\nThe two storey colonial styled villa has a nice garden and is peaceful and although it's much smaller in size than other museums, it has quite a good collection on Dr Sun and the early history of Singapore, especially about the Chinese communities then.\n\nThe exhibits are interesting and insightful, with digital and interactive platforms to bring the history \"live\".\n\nDr Sun, the great revolutionary leader against the Qing dynasty who overthrew the government after 11th uprising attempt in Wuhan and formed the modern Republic of China (中华民国), had his ideologies left a great impression in me. They were 天下为公 and 三民主义!\n\nThe world belongs to everyone and not just for the few elites. And if everyone is being treated equally, justly and fairly and everything is done in accordance to the law and order, the world will be a better, more peaceful and stable place to live in.\n\nIt is good to be back here for a revisitation, the place Dr Sun had stayed during his visits to Singapore and immersed in the rich, diversity and colourful history and legacy of Dr Sun! \n\nThere's also a portion of Singapore's history too, mainly about the Chinese communities during the Sino-war, Japanese occupation etc.\n\nThe museum is closed on Mondays and admission is free for Singaporeans and $8 for tourists.\n\n#sglife #sginstagram #exploresg #sg #love #exploresingapore #historic #instagramsg #instasg #historical #singaporetravel #singapore #singaporeinsiders #sginfluencer #weekendfun #vscocam #sysnmh #museum #MuseumVisit #museumcollection #history #photography #travel #museo #exhibition #culture #photooftheday #museums #photo #travelphotography\n\n@zfy_ed84"
+        },
+        {
+          "title": "Underrated museum that deserves to be on any history buff itinerary",
+          "text": "One of those underrated museum that is off the path of usual tourist traps.\nThe place has a good mixed of artifacts dedicated to Sun Yat Sen and also early Singapore history before independence. Everything is well displayed with simple descriptions attached and some are coupled with good usage of multi media aids which bring the viewing and whole visit a joy. \nHighly recommended to anyone that wants to learn more of Singapore’s role in the ending China’s Qing dynasty rule. \nTip for those that drive, so parked either at the residential car park nearby or the mall the opposite. There are no parking on site."
+        },
+        {
+          "title": "A Historical Visit",
+          "text": "Visited the Sun Yat Sen Nanyang Memorial Hall (Wan Qing Yuan) which was quite an eye-opener into the history of China’s revolution led by Dr Sun Yat Sen from his base in Singapore. It is free admission for Singaporeans and Permanent Residents. \n\nThe exterior grounds of this colonial style villa is very well-maintained with manicured lawn, commemorative sculptures and a spectacular bronze sculpted mural wall depicting the history of Nanyang (now known as Singapore). \n\nThere are more exhibits to see inside the museum, from old pictures and write-outs of Dr Sun Yat Sen and his fellow comrades, Chinese newspapers, printers to traditional footwear, cheongsam and even furniture. Definitely a must-visit for all who love history, especially families with children and teenagers to learn from history. \n"
+        },
+        {
+          "title": "Interesting place to go",
+          "text": "We came here for visit, entrance free, since we staycation at Ramada hotel during the Depavali PH 2021. \n\nI am not a person who is interested in museum but I must say they have a special exhibition during our visit on women fashion (old days) which interested me, especially on the \"shoes\" which were worn by those dynasty women who tied their foot till deformed.... I m surprised at how small the \"shoes\" are, similar to my fist size . Other things on the rebel leader which is also interesting (bedroom etc), a bit of his history, n others who supported him ..\n\nThe environment is soothing. Took quite a bit of  photos . Not much crowd. \nCan visit! \n"
+        },
+        {
+          "title": "History buffs - another place to visit...",
+          "text": "Good place for history buffs to visit.\nFrom how the Chinese in Singapore were instrumental in the forming of the modern Chinese republic to how certain Chinese figures contributed to the development of Singapore as well."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d338367-Reviews-Sun_Yat_Sen_Nanyang_Memorial_Hall-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "12 Tai Gin Road Sun Yat Sen Nanyang Memorial Hall",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "327874",
+        "address_string": "12 Tai Gin Road Sun Yat Sen Nanyang Memorial Hall, Singapore 327874 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.32808",
+      "longitude": "103.84707",
+      "timezone": "Asia/Singapore",
+      "email": "NHB_WQY@nhb.gov.sg",
+      "phone": "+65 6256 7377",
+      "website": "http://sysnmh.org.sg/en/about/overview",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d338367-Sun_Yat_Sen_Nanyang_Memorial_Hall-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#133 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "133"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "90",
+      "review_rating_count": {
+        "1": "0",
+        "2": "0",
+        "3": "12",
+        "4": "39",
+        "5": "39"
+      },
+      "photo_count": "234",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d338367-m66827-Reviews-Sun_Yat_Sen_Nanyang_Memorial_Hall-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Historic Sites",
+              "localized_name": "Historic Sites"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "13210712",
+          "name": "Novena"
+        },
+        {
+          "location_id": "15622429",
+          "name": "Balestier"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "1"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "27"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "24"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "13"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "13"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "12 Tai Gin Road Sun Yat Sen Nanyang Memorial Hall",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "327874",
+        "address_string": "12 Tai Gin Road Sun Yat Sen Nanyang Memorial Hall, Singapore 327874 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Asian Civilisations Museum & Singapore Museum": [
+    {
+      "location_id": "310896",
+      "name": "Asian Civilisations Museum",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/0c/f3/5f/beautiful-building.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/fc/53/a5/asian-civilisations-museum.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/fc/53/a6/asian-civilisations-museum.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-o/01/f7/52/ff/golden-statue.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/11/91/e1/asian-civilisations-museum.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Good",
+          "text": "A place to spend few hours exploring Asian cultures and looking for regional artefacts. Not too busy, so plenty of opportunities to enjoy. Though navigation inside is a bit confusing sometimes, as directions around halls are not clear or lack common sense."
+        },
+        {
+          "title": "Great tour",
+          "text": "Good value for money , 20 Singapore dollars entrance and straight away was told there was a guided tour in 5 mins in English and best still free. A French lady took the tour and it was very informative \nWhen if finished I looked at some of the many rooms that we hadn’t seen. I also went on a VC tour thing ,I have been on one before, if was incredible \nWell done to all"
+        },
+        {
+          "title": "Don't miss the tribal exhibition.",
+          "text": "Some world class exhibitions here. Good displays and very clear explanations with a good flow through the museum's spaces. The exhibition of local tribal cultures to the singapore/ malay/ indonesian area was especially fascinating as these are cultures i knew nothing about and the exhibits were very interesting. The shipwreck ceramics also were incredible, especially considering the age of the shipwreck and how fresh they still looked."
+        },
+        {
+          "title": "Great displays",
+          "text": "This museum focuses on the history of trade between Singapore, China, India, and the Middle East dating back to the 1400's. The displays are very well organized and show many objects of trade. I found this museum most Interesting and informative. The staff is very friendly and helpful. The museum can be seen  from the Fullerton Hotel and is reached by crossing the bridge over the Singapore River. I highly recommend a visit."
+        },
+        {
+          "title": "Fantastic, very informative and very interesting religious viewpoints",
+          "text": "Great exhibition that will open your eyes to the trade that was going on between East and West a thousand years ago (we had international shipping routes and international trading agreements back then too!)\n\nMorphs into the geographic evolution of all the main religions across Asia on the back of the trading activity in a fascinating exhibition."
+        }
+      ],
+      "description": "The Asian Civilisations Museum is devoted to exploring the rich artistic heritage of Asia, especially the ancestral cultures of Singaporeans. Founded in 1993 and in its present building by the Singapore River since 2003, the museum traces its roots to the Raffles Museum, founded in the middle of the 19th century. ACM focuses on the many historical connections between the cultures of Asia, and between Asia and the world. Singapore’s history as a port city that brought people together from all over the world is used as a means of examining the history of Asia. Special exhibitions bring magnificent objects from around the world to our Singapore audience. Programmes like the annual River Nights encourage visitors to connect more closely with culture and the arts.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d310896-Reviews-Asian_Civilisations_Museum-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 Empress Place",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179555",
+        "address_string": "1 Empress Place, Singapore 179555 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.287497",
+      "longitude": "103.85139",
+      "timezone": "Asia/Singapore",
+      "email": "nhb_acm_vs@nhb.gov.sg",
+      "phone": "+65 6332 7798",
+      "website": "http://www.acm.org.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d310896-Asian_Civilisations_Museum-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#29 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "29"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "2254",
+      "review_rating_count": {
+        "1": "7",
+        "2": "30",
+        "3": "215",
+        "4": "774",
+        "5": "1228"
+      },
+      "photo_count": "1620",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d310896-m66827-Reviews-Asian_Civilisations_Museum-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 19:00",
+          "Tuesday: 10:00 - 19:00",
+          "Wednesday: 10:00 - 19:00",
+          "Thursday: 10:00 - 19:00",
+          "Friday: 10:00 - 19:00",
+          "Saturday: 10:00 - 19:00",
+          "Sunday: 10:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "History Museums",
+              "localized_name": "History Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622412",
+          "name": "City Hall"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291610",
+          "name": "The Quays"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "116"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "667"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "365"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "307"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "288"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "1 Empress Place",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179555",
+        "address_string": "1 Empress Place, Singapore 179555 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "National Museum of Singapore": [
+    {
+      "location_id": "324550",
+      "name": "National Museum of Singapore",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/45/9d/0f/national-museum-of-singapore.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/18/ba/ee/4e/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/18/ba/eb/df/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/ff/f6/74/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/ff/f6/73/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Don't miss the chicken curry :-)",
+          "text": "To be honest, I was a bit miffed after buying a ticket to find that most of the museum seemed to be closed except for one permanent gallery and a temporary exhibition, but they were both excellent so it was fine. The permanent gallery is the story of Singapore from pre-history to now which is very well illustrated and laid out. The temporary exhibition was photography of the tribes of the Amazon and was superb. The real high point though was the chicken curry in the cafe which was absolutely excellent!"
+        },
+        {
+          "title": "Look at local history via the eyes of locals and the Amazonas exertion",
+          "text": "It’s an interesting site for every visitor of the town.\nIt is not made in a very professional way, but it is interesting to view in the eyes of locals the history of Singapore \n\nIf you have some spare time, climb up the mountain and go see the place"
+        },
+        {
+          "title": "Definitely worth a visit",
+          "text": "They had 2 very good exhibits; Amazon & History of Singapore. However, the museum is under renovation so they have a weird entrance, one small bathroom and not much common area to sit and relax etc"
+        },
+        {
+          "title": "A Fascinating Journey Through Singapore’s History",
+          "text": "A great place to learn about the country’s rich history in an engaging way. The exhibits are well-curated, with a mix of artifacts, interactive displays, and immersive storytelling. The building itself is beautiful, blending history with modern design. It’s definitely worth a visit if you enjoy culture and history!"
+        },
+        {
+          "title": "A  rainy day experience ",
+          "text": "This is a well presented and informative museum, on the small side but well laid out. Takes you on a journey of Singapore evolution with informative text, photographs and objects. The staff were helpful a welcoming. It was easy to spend a couple of hours here, we did not visit the Amazonian exhibit."
+        }
+      ],
+      "description": "With a history dating back to its inception in 1887, the National Museum of Singapore is the nation's oldest museum with a progressive mind. Its galleries adopt cutting-edge and multi-perspective ways of presenting history and culture to redefine conventional museum experience. A cultural and architectural landmark in Singapore, the Museum hosts innovative festivals and events all year round-the dynamic Night Festival, visually arresting art installations, as well as amazing performances and film screenings-in addition to presenting thought-provoking exhibitions involving critically important collections of artefacts. The programming is supported by a wide range of facilities and services including F&B, retail and a Resource Centre. The National Museum of Singapore re-opened in December 2006 after a three-year redevelopment, and celebrated its 125th anniversary in 2012. The Museum refreshed its permanent galleries and re-opened them on 19 September 2015 for Singapore's Golden Jubilee.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d324550-Reviews-National_Museum_of_Singapore-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "93 Stamford Road National Museum of Singapore",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "178897",
+        "address_string": "93 Stamford Road National Museum of Singapore, Singapore 178897 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.296596",
+      "longitude": "103.84865",
+      "timezone": "Asia/Singapore",
+      "email": "nhb_nm_corpcomms@nhb.gov.sg",
+      "phone": "+65 6332 3659",
+      "website": "http://nationalmuseum.sg/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d324550-National_Museum_of_Singapore-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#35 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "35"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "2952",
+      "review_rating_count": {
+        "1": "31",
+        "2": "62",
+        "3": "271",
+        "4": "1037",
+        "5": "1551"
+      },
+      "photo_count": "2931",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d324550-m66827-Reviews-National_Museum_of_Singapore-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 19:00",
+          "Tuesday: 10:00 - 19:00",
+          "Wednesday: 10:00 - 19:00",
+          "Thursday: 10:00 - 19:00",
+          "Friday: 10:00 - 19:00",
+          "Saturday: 10:00 - 19:00",
+          "Sunday: 10:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Specialty Museums",
+              "localized_name": "Specialty Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622372",
+          "name": "Museum"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        },
+        {
+          "location_id": "15622424",
+          "name": "Bras Basah"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "93"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "920"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "536"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "475"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "397"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "TopAttractions"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        },
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "93 Stamford Road National Museum of Singapore",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "178897",
+        "address_string": "93 Stamford Road National Museum of Singapore, Singapore 178897 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "The Japanese Cemetery Park": [
+    {
+      "location_id": "3459923",
+      "name": "Japanese Cemetery Park",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/23/e6/51/da/floral-arches.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/c8/82/f0/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1a/17/85/d3/at-the-cemetery.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1a/17/85/c7/the-cemetery.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/28/07/f7/5d/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Quiet place for reflection",
+          "text": "Curious, I went to visit the cemetery 🪦 park. It was spacious & serene. Nice place to walk around & read the panels near the gravestones of people who contributed in the past. The trees & plants are well-manicured. Good learning for me."
+        },
+        {
+          "title": "Quiet reflections in peaceful surroundings",
+          "text": "It was cloudy when my wife and I visited the Japanese Cemetery Park. Entry is free. The park is well-kept. As it is located away from the main road, we arrived to an empty park and we came across 4 couples during our 1-hour visit. The tranquility suits the venue.\n\nSignages in English and Mandarin explain the memorials and shrines. They are interesting to understand the early history of Japanese community in Singapore. Some of the memorials and descriptions are poignant in that they explain the sacrifices and hardship of Japanese settlers and residents in Singapore. It is helpful to refer to Wikipedia's write-up on the Japanese Cemetery Park to better understand the memorials and graves of notable Japanese individuals.\n\nA worthwhile visit and time spent."
+        },
+        {
+          "title": "Peaceful and quiet place that I do not mind coming often.",
+          "text": "I was happy to learn more about the history of the Japanese people when they were in Singapore and how they care for those who don't have the means to care for themselves. Admission is free and car parking is available in the park."
+        },
+        {
+          "title": "Worth a hour of your time for something off the beaten track",
+          "text": "The walk there from the nearest MRT is interstinging enough, leafy suburban roads with big houses either side.\n\nWell kept cemetery with some fascinating plaques in english. Starts back in early singapore."
+        },
+        {
+          "title": "A trip into the history of Singapore",
+          "text": "I really like cemeteries, because its always a trip back to the history. the cemetary is well maintained and there are many boards with plenty of informations about the deceased persons and the history of this place."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d3459923-Reviews-Japanese_Cemetery_Park-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "22 Chuan Hoe Avenue",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "549854",
+        "address_string": "22 Chuan Hoe Avenue, Singapore 549854 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.365512",
+      "longitude": "103.876915",
+      "timezone": "Asia/Singapore",
+      "website": "http://www.visitsingapore.com/see-do-singapore/history/memorials/japanese-cemetery-park",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d3459923-Japanese_Cemetery_Park-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#234 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "234"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "36",
+      "review_rating_count": {
+        "1": "0",
+        "2": "0",
+        "3": "8",
+        "4": "16",
+        "5": "12"
+      },
+      "photo_count": "189",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d3459923-m66827-Reviews-Japanese_Cemetery_Park-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0800"
+            },
+            "close": {
+              "day": 1,
+              "time": "1830"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0800"
+            },
+            "close": {
+              "day": 2,
+              "time": "1830"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0800"
+            },
+            "close": {
+              "day": 3,
+              "time": "1830"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0800"
+            },
+            "close": {
+              "day": 4,
+              "time": "1830"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0800"
+            },
+            "close": {
+              "day": 5,
+              "time": "1830"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0800"
+            },
+            "close": {
+              "day": 6,
+              "time": "1830"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0800"
+            },
+            "close": {
+              "day": 7,
+              "time": "1830"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 08:00 - 18:30",
+          "Tuesday: 08:00 - 18:30",
+          "Wednesday: 08:00 - 18:30",
+          "Thursday: 08:00 - 18:30",
+          "Friday: 08:00 - 18:30",
+          "Saturday: 08:00 - 18:30",
+          "Sunday: 08:00 - 18:30"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Cemeteries",
+              "localized_name": "Cemeteries"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622390",
+          "name": "Rosyth"
+        },
+        {
+          "location_id": "13210710",
+          "name": "Hougang"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "4"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "11"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "3"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "9"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "22 Chuan Hoe Avenue",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "549854",
+        "address_string": "22 Chuan Hoe Avenue, Singapore 549854 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Dalhousie Obelisk, a Singapore Landmark": [
+    {
+      "location_id": "2341798",
+      "name": "Dalhousie Obelisk",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/03/41/ac/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/e9/ec/db/dalhousie-obelisk.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/ac/de/06/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/ac/de/05/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/ac/dd/c4/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Singapore's oldest monument.",
+          "text": "The inscribed plaques were more of interest that the ordinary monument to which they are attached. Inscribed in English, Jawi, Chinese and Tamil. \nThe English inscription reads; - \"Erected by the European, Chinese, and Native Inhabitants of Singapore to commemorate the visit in the month of February 1850, of the Most Noble the Marquis of Dalhousie, K. T., Governor-General of British India on which occasion he emphatically recognised the wisdom of liberating commerce from all restraints under which enlightened policy this Settlement has rapidly attained its present rank among British Possessions and with which its future prosperity must ever be identified.\"\nIt was the first public monument erected in the then Straits Settlements in 1851, and subsequently relocated on a number of occasions before arriving in its present location in 1911. Its of brick construction and plastered over, standing on a platform with short wall/platform at each corner with a decorative pinnacle lamp atop each."
+        },
+        {
+          "title": "Obelisk to honour Governor-General of India",
+          "text": "This monument was raised to mark the visit of James Andrew Broun-Ramsay, 1st Marquess of Dalhousie. A Scotsman and colonial administrator in British India, he rose to become Governor-General of India. This obelisk was raised by the Chinese and Malay citizens of Singapore to mark his visit in 1850. Not a must see, but it’s a bit of a landmark in Boat Quay and is opposite Victoria Theatre, on Empress Lawn."
+        },
+        {
+          "title": "A monument to Colonialism ",
+          "text": "The obelisk stands to commemorate the work of the Marquis of Dalhousie who served the British administration governing the Strait Settlements. Dalhousie also was Governor General of India and played an important role in its advancement. Worth looking at if your in the area but nothing special."
+        },
+        {
+          "title": "In the area, have a look",
+          "text": "Sunday 20th October and we were out and about exploring and sightseeing in Singapore.\n\nWe came across the The obelisk which is situated at Empress Place, it is very close to a number of other attractions like the Asian Civilisations Museum, Victoria Theatre and Concert Hall and Anderson Bridge. \n\nA lot to see in the area, so worth including with other things, not worth a specific trip.\n\nThe Obelisk commemorates the visit of the governor-general of India (1848–1856), the Marquis of Dalhousie, James Andrew Broun-Ramsay, to Singapore in February 1850."
+        },
+        {
+          "title": "Quick glimpse",
+          "text": "Ok if you are walking by this area, you can just have a quick look, if you have the time. Nothing much about it but definitely it is a reminder of the old Egyptian obelisk \"the Cleaopatra's needle\" now located on th Thames river side in London"
+        }
+      ],
+      "description": "It is believed that the design was modelled after “Cleopatra’s Needle” on the Thames Embankment in London, which might explain the British influences in its tall, needle-like architectural structure.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2341798-Reviews-Dalhousie_Obelisk-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 Empress Place Empress Place Building",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179555",
+        "address_string": "1 Empress Place Empress Place Building, Singapore 179555 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.28755",
+      "longitude": "103.85142",
+      "timezone": "Asia/Singapore",
+      "website": "http://www.yoursingapore.com/content/traveller/en/browse/see-and-do/arts-and-entertainment/architecture/dalhousie-obelisk.html?TAHotelCode=73",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2341798-Dalhousie_Obelisk-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#509 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "509"
+      },
+      "rating": "3.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.0-66827-5.svg",
+      "num_reviews": "41",
+      "review_rating_count": {
+        "1": "0",
+        "2": "1",
+        "3": "31",
+        "4": "9",
+        "5": "0"
+      },
+      "photo_count": "52",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2341798-m66827-Reviews-Dalhousie_Obelisk-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Architectural Buildings",
+              "localized_name": "Architectural Buildings"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622412",
+          "name": "City Hall"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291610",
+          "name": "The Quays"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "1"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "9"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "18"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "4"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "4"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "1 Empress Place Empress Place Building",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179555",
+        "address_string": "1 Empress Place Empress Place Building, Singapore 179555 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Raffles Statue â€“ Sir Stamford Raffles Landing Site": [
+    {
+      "location_id": "2139569",
+      "name": "Raffles City",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0f/47/d9/e3/photo0jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/41/2f/0b/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/41/2f/0a/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/41/2f/09/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/41/2f/08/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Hundred Grains Restaurant",
+          "text": "A group of us met at Raffles City for lunch. A couple of friends got there early so they decided to explore the place. In the past, we had dined in the basement.  There  isn’t much choice there.  This time they turned into City Link and saw the Hundred Grains Restaurant.  It looked interesting so everyone agreed to dine there.  It’s buffet style.  We got a tray and filled it with food. Then we went to the cashier to get it weighed. It costs $3.60 per 100gm.  We can take as much or as little as we want.  Brown rice, white rice and porridge are free. So are the drinks and fruit.  It’s a great idea because there was no waste.  Everyone was bringing their leftovers home.  The MRT station is City Hall and City Link is on the right, after one exits the station. It’s clearly marked. I enjoyed the food and wouldn’t hesitate to return again."
+        },
+        {
+          "title": "Aging mall",
+          "text": "The basement food and supermarket level is the most crowded. The upper floors are quiet but you can get restaurants, optical shops etc. there"
+        },
+        {
+          "title": "Raffle city",
+          "text": "Only exchanger I found here\n Nice and tidy place. Nearby the swiss hotel stamford. Many shops you will find. Enjoy the ride"
+        },
+        {
+          "title": "Busy mal,",
+          "text": "Raffles City's is connected to the City Hall MRT station. It's very crowded with some good shops like the chocolate shop. There is a large market in the basement. Since my hotel wasn't nearby, and the weather was so hot, I couldn't buy any food to take away. Good for shopping."
+        },
+        {
+          "title": "Confusing toilet signs that the fact that I have to go inside the exit sign just to get to the toilet",
+          "text": "The signs are so confusing that when I go find the toilet sign I thought the toilet was there that the fact that I had to get through the whole exit sign and we have to go in the exit sign just to find the toilet"
+        }
+      ],
+      "description": "\"Situated in the Civic District close to historic and tourist sites, Raffles City Shopping Centre is a haven for consumers looking for luxury items. Built on the site of a former school (Raffles Institution), Raffles City is downtown shopping at its finest. The mall has a number of luxury and designer stores such as Omega, Thomas Sabo, Cortefiel and Tommy Hilfiger, among others. Here, you’ll also find big department stores like Marks & Spencer and Robinsons, and fashion chains like Topshop, River Island and Skyla. In fact, Raffles City covers most shopping bases with fashion, books, music, sports, toys, eyewear and beauty all available above the City Hall MRT station, which makes getting here all the more convenient. \"",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2139569-Reviews-Raffles_City-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "252 North Bridge Rd",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179103",
+        "address_string": "252 North Bridge Rd, Singapore 179103 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.294054",
+      "longitude": "103.85316",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6318 0238",
+      "website": "http://www.rafflescity.com.sg/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2139569-Raffles_City-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#73 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "73"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "540",
+      "review_rating_count": {
+        "1": "2",
+        "2": "4",
+        "3": "91",
+        "4": "281",
+        "5": "162"
+      },
+      "photo_count": "431",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2139569-m66827-Reviews-Raffles_City-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "2200"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 22:00",
+          "Tuesday: 10:00 - 22:00",
+          "Wednesday: 10:00 - 22:00",
+          "Thursday: 10:00 - 22:00",
+          "Friday: 10:00 - 22:00",
+          "Saturday: 10:00 - 22:00",
+          "Sunday: 10:00 - 22:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "shopping",
+          "localized_name": "Shopping"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Shopping",
+          "localized_name": "Shopping",
+          "categories": [
+            {
+              "name": "Shopping Malls",
+              "localized_name": "Shopping Malls"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622412",
+          "name": "City Hall"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "25"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "181"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "93"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "84"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "55"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "252 North Bridge Rd",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179103",
+        "address_string": "252 North Bridge Rd, Singapore 179103 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Singapore Philatelic Museum": [
+    {
+      "location_id": "446422",
+      "name": "Children's Museum Singapore",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/15/08/50/90/philatelic-museum-singapore.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/57/9b/ab/singapore-philatelic.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/04/0e/bd/77/singapore-philatelic.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1b/4b/36/07/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1b/4b/36/05/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A place to visit",
+          "text": "Come and try visiting these places. You will love and mesmerize by the beauty of it. we will surely come and visit longer!"
+        },
+        {
+          "title": "Must go before its closure",
+          "text": "I was attracted to it because of the exhibition on Little Prince. I had long wanted to go earlier and been tracking the days. I am glad that I have finally make it there. I loved it at once and could not bear to go. \nThere are exhibits about the author, the book on Little Prince as well as the exhibits in the dark. It is a wonderful experience. Greatly recommended for all who loves Little Prince. "
+        },
+        {
+          "title": "Very Interesting and Fun",
+          "text": "Singapore Philatelic Museum was opened on August 19, 1995. Singapore Philatelic Museum is housed in a century-old, double-story, colonial building. The original plans of this building were approved on 22 June 1906.\nThe museum collections start from the 1830s and include stamps from different countries around the world. \nSome of the stamps in the display comprise of stamps make from gold foil, stamps made of silver, embossed stamps, scented stamps (scents include rose, coffee, chocolate, lemon, strawberry, jasmine tea, honey, ginger bread), glow in the dark stamps, stamps embellished with Swarovski crystals, lace embroidered stamp, cloth stamps to list a few. \nThe museum houses different exhibits and permanent displays. One of the current exhibits is based on the book The Little Prince written by Antoine de Saint-Exupéry, the exhibition celebrates the 75th anniversary of the publication in 2018. This exhibit is very interesting, fun for people of all ages esp. for children and is also interactive. Free admission for resident s and $8 for non-residents. There is a restroom and a gift shop in the museum."
+        },
+        {
+          "title": "The little prince ( Now till 17 Mar 2019) & Museum Under renovation ( 18 March 2019 till tentative end of 2020)",
+          "text": "Last visited was 2017 and I decided visited this place again with our special new family member  . I heard that latest exhibition theme is “ The little prince “. Stamp Museum is going under renovation around 18 march 2019 and reopen tentative end of 2020. \n\nLittle prince exhibition is located at level 1. There are a lot of sculpture / artifact related to little prince and I also noticed the wall furnish w\nith blue color .  Do note that don’t touch some of sculpture / artifact as indicated . \n\nOrange room ( level 1) : Show how Singapore stamp history grow . \n\nHeritage Room ( Level 2) : We let our new family member to explore the old day of Singapore look like . We also allow him touch the wooden slipper (clog ) Chinese clogs (木屐) or 'cha kiak . I wore couple of time during my  childhood and ppl from far can hear the wooden sound . \n\nRoom of rarities (level 2) : Show type of mail box and stamp chop used in old days . \nYou’ve Got Mail – Seeing is Believing Unusual Stamp ( Level 2) : There are a lot of stamps come with aroma(press the pump and place your nose near the outlet hole) or special effect  embedded on it . It is a must to see and smell it. \n\nAdmission Fee: Free admission for Singaporean . ( need to show 11B or IC ). For more information on fee do check on their website\n\nStroller: Please ask the staff when to keep it.\nSmoking : It is not allow .\n\nConclusion : It is worth visit this place and you can some souvenir such as stamp , key chains , 1st cover  near the main entrance  . We will definitely visited this place once open in 2020 with our new family member ."
+        },
+        {
+          "title": "Visit before it closes",
+          "text": "I've always made a point to drop by when in town. Like to buy the stamps and view the exhibits-- cant believe it opened in 95! Will definitely go down soon before 18 march, it will close for revamp until 2020 aww"
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d446422-Reviews-Children_s_Museum_Singapore-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Coleman St",
+        "street2": "23-b",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179807",
+        "address_string": "Coleman St 23-b, Singapore 179807 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.292913",
+      "longitude": "103.84889",
+      "timezone": "Asia/Singapore",
+      "email": "nhb_cmsg@nhb.gov.sg",
+      "phone": "+65 6337 3888",
+      "website": "http://spm.org.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d446422-Children_s_Museum_Singapore-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#90 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "90"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "247",
+      "review_rating_count": {
+        "1": "0",
+        "2": "7",
+        "3": "37",
+        "4": "111",
+        "5": "92"
+      },
+      "photo_count": "666",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d446422-m66827-Reviews-Children_s_Museum_Singapore-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Children's Museums",
+              "localized_name": "Children's Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622372",
+          "name": "Museum"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622418",
+          "name": "Fort Canning"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "6"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "47"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "76"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "50"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "22"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "Coleman St",
+        "street2": "23-b",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179807",
+        "address_string": "Coleman St 23-b, Singapore 179807 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Old Ford Factory Singapore Museum": [
+    {
+      "location_id": "14149881",
+      "name": "Former Ford Factory",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/c0/18/98/photo0jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/13/2f/95/b4/the-ford-logo-old-fashioned.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2c/27/db/bc/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2c/27/db/bb/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2c/27/db/ba/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A great way to get to know modern Singapore history",
+          "text": "Highly informative exhibition of various artefacts, audio visuals and texts about the wartime fall of Singapore to the Japanese, the subsequent reconquest and the development towards independence. The narrative seems historically well balanced and the British surrender was signed in this very building which I hadn’t realised. There’s a lot to take in here, so bring your reading glasses! In fact, it’s a more reading-intensive display than many museums, so perhaps better suited to adults and older children than the very young. It’s also quite a remote location and there’s no refreshments beyond a water fountain, so be prepared for that. Staff kindly telephoned a taxi for us when we left, since we didn’t want to use roaming data to get a Grab. At just $7 each to enter, this is great value and much recommended."
+        },
+        {
+          "title": "Very insightful! Great place for all keen in Singapore under Japanese Occupation",
+          "text": "A Gem of Singapore History during Japanese Occupation.. worth the visit.. all secondary students should pay a visit to know this dark time and not take our Peace for granted."
+        },
+        {
+          "title": "Amazing exhibition",
+          "text": "This former factory has been turned into an exhibition space for the Japanese Occupation in WWII. The surrounding area and the factory is formed as a historical trail. Worth the journey if you have half day to spend. Don't forget to bring a jacket as the venue is super cold."
+        },
+        {
+          "title": "Don’t bother going out of your way, but check it out if in the area",
+          "text": "Don’t get me wrong, this is a lovely little museum and well designed by the archives folk. I just felt because I had been to other Singapore museums and heard a lot of the history before, that I didn’t get as much out of it as I hoped. Also I was very disappointed with the external appearance of the building which is clearly overdue for some cleaning & painting. I came for the art deco building as much as the exhibition. A friend showed me her photos from 2016 and the building looked much better then."
+        },
+        {
+          "title": "Interesting.",
+          "text": "Very interesting place. Not very big,but chronicles the fall of Singapore and life during the Japanese occupation and after the war. This place could use a little cafe,the only refreshments being a vending machine outside of the main building.\nThe staff were very knowledgeable and friendly."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d14149881-Reviews-Former_Ford_Factory-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "351 Upper Bukit Timah Road",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "588192",
+        "address_string": "351 Upper Bukit Timah Road, Singapore 588192 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.352714",
+      "longitude": "103.76922",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6462 6724",
+      "website": "http://www.nas.gov.sg/formerfordfactory",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d14149881-Former_Ford_Factory-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#107 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "107"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "65",
+      "review_rating_count": {
+        "1": "0",
+        "2": "0",
+        "3": "5",
+        "4": "13",
+        "5": "47"
+      },
+      "photo_count": "60",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d14149881-m66827-Reviews-Former_Ford_Factory-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Military Museums",
+              "localized_name": "Military Museums"
+            },
+            {
+              "name": "History Museums",
+              "localized_name": "History Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622330",
+          "name": "Bukit Batok"
+        },
+        {
+          "location_id": "15622576",
+          "name": "Hillview"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "1"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "16"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "14"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "12"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "7"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "351 Upper Bukit Timah Road",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "588192",
+        "address_string": "351 Upper Bukit Timah Road, Singapore 588192 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Singapore Coins and Notes Museum & Museum Singapore": [
+    {
+      "location_id": "1438273",
+      "name": "Buddha Tooth Relic Temple and Museum",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0b/ce/1f/25/photo2jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-o/03/cd/dc/ac/buddha-tooth-relic-temple.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/3f/3b/ad/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/3f/3b/b2/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/3f/3b/b7/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Free to visit, full of history",
+          "text": "Built in 2007 at a cost of $75,000,000 Singapore dollars this Tang-styled Temple resides prominently in Chinatown.  Home to thousands of statues, two museums and a lot of scripture believers will be drawn to the enormous gold vessel reportedly home to Buddha's left canine tooth.  Free to visit."
+        },
+        {
+          "title": "Not enough time in Temple",
+          "text": "The Buddha Tooth Relic temple & museum is in china town, this stunning temple hall with over 1000 Buddha on the first floor is amazing.\nThe interior on the ground floor was large & lovely, red & gold everywhere. Built in the 2000’s it has a lift to the fifth floor, where is the tooth relic is but unfortunately no photos can be taken & you must remove your shoes. The museum & the rest of the building you leave your shoes on. I wore shorts just about the knees & had no trouble entering the temple.\nThis is another must do while in Singapore."
+        },
+        {
+          "title": "Amazing!",
+          "text": "One of the coolest things I've ever seen while travelling! They provide cover ups if you're wearing shorts or tank tops. The temple was absolutely stunning. Make sure you visit all the floors! The sanctuary on the roof was beautiful and so peaceful!"
+        },
+        {
+          "title": "Lovely Temple",
+          "text": "This is a beautiful temple with large statues in the front and many smaller ones on the walls. Appropriate attire is required. They have some scarves to hand out if your knees or shoulders are bare. We went up to the 4th floor to see the Buddha Tooth Relic which was behind glass. You have to take off your shoes. Photo taking was not allowed here. They had beads for sale. \n\nThe monks were preparing for a prayer service when we were there. You have to make reservations for a kneeling bench spot to be part of the prayers. As they were closing, we didn’t have time to visit the roof top garden or the museums on the other floors. Yes, it’s worth a visit. The energy was very good here in here."
+        },
+        {
+          "title": "Really beautiful temple",
+          "text": "Inside it’s awesomely opulent, really over the top in style.\nMain features are the hall of 100 Buddhas on level 1, and the repository of Buddha’s tooth on level 5.  We also visited level 4 with lots of relics, but felt that was less interesting to visitors.\nThe disabled will have no problems, there’s step free access, and lifts between floors, although I don’t think you can visit the roof garden without climbing stairs.\nLike many famous places of worship, it’s swamped by visitors, so don’t expect to see many paying their respects to the Buddha. We did see several meditating, but to see Buddhism at its best, you’ll need to visit another temple.\nOverall, this is a splendid place to visit when you’re in Singapore."
+        }
+      ],
+      "description": "The Buddha Tooth Relic Temple and Museum (BTRTM) was founded in 2002 by Venerable Shi Fazhao. It was registered by the Registrar of Societies in 20th February 2003, and as a charity under the Charities Act in 8th January 2004. The Temple is dedicated to the Maitreya Buddha, which means 'The Compassionate One', and also called 'The Future Buddha'. (A)WEEKLY FREE GUIDED TOUR: BTRTM is pleased to offer a 1 1/2 - 2 hrs long guided tour of the Temple every Saturdays at 2pm. The tour will be conducted free-of-charge in English by the temple's Volunteers guides. Limited slots are available per weekly session. Confirmed registration is based on first-come-first-serve basis. (B)DISCOVERING BUDDHISM: Shakyanmuni Buddha had gained insight into the truth, perfected the qualities of wisdom and compassion over 2560 years ago. His teachings develops clarity in minds, enables abilities to end suffering and finds lasting happiness. Buddha Tooth Relic Temple is carrying on the mission in offering \"Discovering Buddhism' programme. 'Discovering Buddhism' is a specially designed programme for participants to gain experiential taste of Chinese Mahayana Buddhist etiquette, Basic Buddhist teachings and Basic Meditation within a day. This English taught programme is suitable for both tourists who wish to learn more about Buddhism and experienced learners who needs a refresher. Participants will benefit from the interactive and engaging teaching led by Venerable Wu Xiang and Venerable Ru Zhi who have more than a decade experience teaching Buddhism and Meditation in different cultural settings! [Chinese Mahayana Buddhist Etiquette] Buddhist etiquette is an important part of every Buddhist life. It expresses religious sentiments to the Buddha, the Teacher (Monk or Nun) and promotes gracefulness in social interactions. This is also a mean of training in mindfulness in every action one is taking. [Basic Buddhist teachings] Buddhism has been transmitted over the past centuries because of its timeless and enduring message to the spiritual needs of man in finding true peace, happiness, and well-being. In this part of the programme, learn about the basic essential knowledge of Buddhism. [Basic Meditation] Buddhist have been practicing meditation in cultivating calm, focused and positive states of mind. Introductory of technique will be taught to enable the participants to learn practical tips on how to achieve a clearer state of mind and focus better. Things to take note : * Avoid wearing hats, shorts or revealing tops * The organizer reserves the right to cancel the tour due to unforeseen circumstances. In such instances, registrants will be notified via their mobile phones.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d1438273-Reviews-Buddha_Tooth_Relic_Temple_and_Museum-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "288 South Bridge Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "058840",
+        "address_string": "288 South Bridge Road, Singapore 058840 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.281531",
+      "longitude": "103.84424",
+      "timezone": "Asia/Singapore",
+      "email": "services@btrts.org.sg",
+      "phone": "+65 6220 0220",
+      "website": "http://www.btrts.org.sg/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d1438273-Buddha_Tooth_Relic_Temple_and_Museum-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#22 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "22"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "6540",
+      "review_rating_count": {
+        "1": "16",
+        "2": "48",
+        "3": "526",
+        "4": "2339",
+        "5": "3611"
+      },
+      "photo_count": "6802",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d1438273-m66827-Reviews-Buddha_Tooth_Relic_Temple_and_Museum-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0700"
+            },
+            "close": {
+              "day": 1,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0700"
+            },
+            "close": {
+              "day": 2,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0700"
+            },
+            "close": {
+              "day": 3,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0700"
+            },
+            "close": {
+              "day": 4,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0700"
+            },
+            "close": {
+              "day": 5,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0700"
+            },
+            "close": {
+              "day": 6,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0700"
+            },
+            "close": {
+              "day": 7,
+              "time": "1700"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 07:00 - 17:00",
+          "Tuesday: 07:00 - 17:00",
+          "Wednesday: 07:00 - 17:00",
+          "Thursday: 07:00 - 17:00",
+          "Friday: 07:00 - 17:00",
+          "Saturday: 07:00 - 17:00",
+          "Sunday: 07:00 - 17:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Sacred & Religious Sites",
+              "localized_name": "Sacred & Religious Sites"
+            }
+          ]
+        },
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Specialty Museums",
+              "localized_name": "Specialty Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622374",
+          "name": "Outram"
+        },
+        {
+          "location_id": "15622676",
+          "name": "Central Business District"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291616",
+          "name": "Chinatown"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "235"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "2191"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "915"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "1296"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "1087"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "TopAttractions"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        },
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "288 South Bridge Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "058840",
+        "address_string": "288 South Bridge Road, Singapore 058840 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Singapore City Gallery": [
+    {
+      "location_id": "315469",
+      "name": "Singapore City Gallery",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/4f/48/03/photo8jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/41/52/e0/singapore-city-gallery.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/13/08/aa/a5/a-clearer-bird-eye-view.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/13/08/ec/20/urban-park-ura-s-former.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/13/08/bf/1f/located-within-the-permanent.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Nice visit",
+          "text": "So nice to learn more about city planning. And the plans for the future of Singapore. \nFree to visit. It is located next to the Maxwell foodcourt. So nice to spend time here."
+        },
+        {
+          "title": "A Fascinating Experience",
+          "text": "We  thoroughly enjoyed our visit to the museum. We learnt so much. The way in which the rooms have been created was fascinating. Information was easily accessible . Extremely good value for money ! \nWould recommend a visit!"
+        },
+        {
+          "title": "A great place to stop for Singapore city information.",
+          "text": "Beautifully designed, well maintained, clean, open and very informative. The gigantic miniature city model said it all about Singapore. \nLocated inside Chinatown, next to the Maxwell Food Centre.\nThis is a great place to stop by to catch a break and to learn more about Singapore. \nHighly recommend!"
+        },
+        {
+          "title": "Hidden gem giving the best historical perspective of Singapore",
+          "text": "This was a very pleasant surprise!  I loved this overview of Singapore, and best of all it's free.  There are 2 floors.  The ground floor is very much for architecture buffs.  There are detailed models of various public housing projects of note in Singapore.  I got a free guided tour, although it was suited for hard-core architects.  On the second floor are galleries showing the history of Singapore.  Honestly I thought these were much more informative and better presented than even the National Museum.  At the end is a scale model of Singapore down to every building on the island.  Plus, there are lines denoting the planned expansion by reclaiming land from the sea.  It's fascinating and I think the best museum in the country."
+        },
+        {
+          "title": "A must visit to see the amazing this the city is busy with.",
+          "text": "One of the coolest places to visit in Singapore. It gives such a great overview of what's going on behind the scenes in the city. Would definitely recommend it to anyone. Plus, it's free!"
+        }
+      ],
+      "description": "Singapore City Gallery is a great starting point to get to know the city for free. Located beside the Maxwell food centre in the historic district of Chinatown, this 3 storey visitor centre goes beneath the skin of the city to understand how the city came to be, that even though it’s a dense built-up city of tar, glass and concrete, it is still so green, has memorable buildings, historic districts and walkable streets. You can imagine and design your own version of Marina Bay or explore plans long into the future like Greater Southern Waterfront city. The main draw is an enormous model replica of the City Centre with uncannily accurate miniatures of building and streetscapes. Look out for an illustrative map drawn by Lee Xin Li. It will sure to bring back memories of Singapore, past and present. Before you leave, catch the dramatic 3-min Island Wide Model show screened every 20 mins at level 1.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d315469-Reviews-Singapore_City_Gallery-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "45 Maxwell Road",
+        "street2": "The URA Centre",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "069118",
+        "address_string": "45 Maxwell Road The URA Centre, Singapore 069118 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.279854",
+      "longitude": "103.845055",
+      "timezone": "Asia/Singapore",
+      "email": "ura_gallery@ura.gov.sg",
+      "phone": "+65 6221 6666",
+      "website": "http://www.ura.gov.sg/Corporate/Singapore-City-Gallery",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d315469-Singapore_City_Gallery-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#23 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "23"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "534",
+      "review_rating_count": {
+        "1": "0",
+        "2": "1",
+        "3": "39",
+        "4": "182",
+        "5": "311"
+      },
+      "photo_count": "460",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d315469-m66827-Reviews-Singapore_City_Gallery-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0900"
+            },
+            "close": {
+              "day": 1,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0900"
+            },
+            "close": {
+              "day": 2,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0900"
+            },
+            "close": {
+              "day": 3,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0900"
+            },
+            "close": {
+              "day": 4,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0900"
+            },
+            "close": {
+              "day": 5,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0900"
+            },
+            "close": {
+              "day": 6,
+              "time": "1700"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 09:00 - 17:00",
+          "Tuesday: 09:00 - 17:00",
+          "Wednesday: 09:00 - 17:00",
+          "Thursday: 09:00 - 17:00",
+          "Friday: 09:00 - 17:00",
+          "Saturday: 09:00 - 17:00",
+          "Sunday: Closed"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Specialty Museums",
+              "localized_name": "Specialty Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622676",
+          "name": "Central Business District"
+        },
+        {
+          "location_id": "15622380",
+          "name": "Maxwell"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "19"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "131"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "104"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "108"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "93"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "45 Maxwell Road",
+        "street2": "The URA Centre",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "069118",
+        "address_string": "45 Maxwell Road The URA Centre, Singapore 069118 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Changi Museum Singapore": [
+    {
+      "location_id": "324543",
+      "name": "Changi Chapel and Museum",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/1d/10/80/6c/changi-chapel-that-greets.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1d/10/80/6e/the-changi-camp-was-a.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/22/ac/c3/singapore.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/2b/5b/fe/bush-at-the-back-of-the.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/12/1e/28/0b/outside.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A moving history lesson on the Japanese Occupation",
+          "text": "This is something for history buffs, or if you had family who were in Singapore during the Japanese Occupation.  It is out by the Singapore Airport, next to the forbidding bulk of Changi Prison.  The Museum is a gallery wrapped around the very simple, and moving, chapel which served Christians and Jews.  Great thanks to the many Australian contributors, who recorded the life of a  large group of young Australians interned. The map of the site shows there was a Women's camp, and the Indian Army Camp, which deserve their own galleries. \nThe numbers who passed through, and the numbers who never returned from work camps outside Singapore, are sobering. \nI was surprised at the amount of creativity the place unleashed in its  population. 'Changi University', the skills taught to inmates by inmates; music, the visual arts; the diaries and the poetry. \nIn the chapel space there is a wall where you can leave your comments on your visit. The reference to how Japanese record their wishes, when visiting their temples, is unmistakable."
+        },
+        {
+          "title": "Highly Recommended",
+          "text": "We thoroughly enjoyed our visit to the chapel & museum. It was excellent throughout. The ladies (staff) around the reception area were all very friendly, polite & helpful. The exhibition was very interesting and it was educational reading & listening to the stories of the experiences of people affected by the Japanese occupation. The chapel was also very thought provoking.\nWe definitely recommend a visit to this museum."
+        },
+        {
+          "title": "Little talk of Australian suffering",
+          "text": "Too little focus on the death and suffering, an entire Australian tour group had a talk not focussed on our own nationals and their plight, replicas of replicas, I had to ask “how many prisoners died”"
+        },
+        {
+          "title": "A moving experience",
+          "text": "Alvin was a very passionate volunteer with a wealth of knowledge.   He went above and beyond to make our tour very informative."
+        },
+        {
+          "title": "Disappointing exhibition",
+          "text": "Unfortunately we found the new updated Museum to be a sanitised and politically correct version of WW2 and life as a POW. The stories made the camp sound like a holiday almost, and the photos of well fed prisoners does not tally with the skeletal pictures of the men when they were liberated. No mention of the brutality of the Japanese. After seeing the 'old' museum, I was looking forward to a much better display. Very disappointing"
+        }
+      ],
+      "description": "The newly revamped Changi Chapel and Museum (CCM) features new content and artefacts presented in an intimate and engaging format to tell the story of the prisoners of war and civilians interned in Changi prison camp during the Japanese Occupation. As part of the revamp, the National Museum of Singapore which manages Changi Museum has been collecting stories and personal objects from families of former internees that emphasise their personal experiences. The museum’s narrative is centred on remembrance and reflection, encouraging visitors to contemplate both the hardships that the internees underwent, as well as their courage and resilience in the face of difficulties.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d324543-Reviews-Changi_Chapel_and_Museum-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1000 Upper Changi Road North",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "507707",
+        "address_string": "1000 Upper Changi Road North, Singapore 507707 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.362242",
+      "longitude": "103.97395",
+      "timezone": "Asia/Singapore",
+      "email": "changi_museum@nhb.gov.sg",
+      "phone": "+65 6242 6033",
+      "website": "http://www.nhb.gov.sg/changichapelmuseum",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d324543-Changi_Chapel_and_Museum-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#31 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "31"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "2100",
+      "review_rating_count": {
+        "1": "14",
+        "2": "21",
+        "3": "174",
+        "4": "664",
+        "5": "1227"
+      },
+      "photo_count": "294",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d324543-m66827-Reviews-Changi_Chapel_and_Museum-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 2,
+              "time": "0930"
+            },
+            "close": {
+              "day": 2,
+              "time": "1730"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0930"
+            },
+            "close": {
+              "day": 3,
+              "time": "1730"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0930"
+            },
+            "close": {
+              "day": 4,
+              "time": "1730"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0930"
+            },
+            "close": {
+              "day": 5,
+              "time": "1730"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0930"
+            },
+            "close": {
+              "day": 6,
+              "time": "1730"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0930"
+            },
+            "close": {
+              "day": 7,
+              "time": "1730"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: Closed",
+          "Tuesday: 09:30 - 17:30",
+          "Wednesday: 09:30 - 17:30",
+          "Thursday: 09:30 - 17:30",
+          "Friday: 09:30 - 17:30",
+          "Saturday: 09:30 - 17:30",
+          "Sunday: 09:30 - 17:30"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "History Museums",
+              "localized_name": "History Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622506",
+          "name": "Changi West"
+        },
+        {
+          "location_id": "15622335",
+          "name": "Changi"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "57"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "912"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "251"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "347"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "300"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "1000 Upper Changi Road North",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "507707",
+        "address_string": "1000 Upper Changi Road North, Singapore 507707 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "MINT Museum of Toys Singapore & Toy Museum": [
+    {
+      "location_id": "1452075",
+      "name": "MINT Museum of Toys",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-p/29/7a/dd/f1/ar-museum-experience.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/87/f8/ef/mego-man-from-outerspace.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/87/f8/de/shadow-high-merchandises.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/87/f8/d7/these-little-explorers.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/29/87/f8/cd/hello-welcome-to-the.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Depends on how you look at it... Kind of an Anglophile's dream come alive!",
+          "text": "Yeah, we were a little torn about this place too:\n\nIf you're here with kids who by nature have short attention spans, it might be hard to stay more than 20 minutes and to fully appreciate everything here.\n\nIf you grew up loving everything British, and have some kind of understanding about how all these toys/ memorabilia were most likely painstakingly preserved AND put together, over DECADES, by some private collectors - you'll probably be utterly impressed about how extensive and incredibly well-preserved the collections here are. Despite how a little boring and cold the displays appear, you gotta admit, they have lots of REAL unique antique toys AND memorabilia in there.\n\nThough it is also good to note that - the sensitive, new-age folks might find some exhibits offensive (e.g. there's quite a lot of erm......... African and Chinese toys from that era, and from that perspective). But we love history and culture, and we get that every era's got their thing. \n\nPerhaps they don't just need a new theatre/show - but better storytellers/marketers with fresh eyes to draw in and to remind visitors, that it is okay to look and learn from the past, in order to know how to navigate the present/future better. Maybe not so much of, \"Keep Calm and Carry On\" but rather, \"Let's have a conversation and learn together\" kinda messaging to make it an overall more meaningful and engaging experience for visitors.\n\nJust a Penny (or Farthing) worth of thoughts."
+        },
+        {
+          "title": "Great museum",
+          "text": "Wow what a blast this museum is a must see for anyone from the 60s it was amazing . The toys were well displayed and in mint condition we were amazed to see such a great collection on 5 floors we could have spent double the time we did it was so good we would highly recommend this museum"
+        },
+        {
+          "title": "Not worth the price",
+          "text": "A disappointment. I can appreciate the value of this great collection of historical toys, but the price being charged for the experience is not worth it. We bought discounted tickets at $30 each (instead of $35) and still not worth it. Museum is quite small and does not take too long to walk through. Recommend they consider halving their prices to get more people in. The upside was we had the whole place (all 5 narrow floors) to ourselves."
+        },
+        {
+          "title": "Just don’t!",
+          "text": "For S$30 per person - this felt like a rip off. It’s 4-5 small rooms with toys. My husband is a toy enthusiast and he thought it was a rip off. Took us 15 mins to go through the whole thing. Took us longer to navigate their website to buy tickets than to see all the toys."
+        },
+        {
+          "title": "What a hidden gem!!!!",
+          "text": "I love nostalgia and I love toys.   \n\nThis place is well done.  I have been to a few toy museums, and this is easily the best laid-out and organized toy museum I personally have seen.\n\nThey have some amazing exhibits organized by subjects.\nA few of my favorites: Astroboy, Ultraman, a really old Batman collection, a newer Darth Maul, barbies, Daleks, and even Sesame Street.  What I appreciated is been able to see some toys that would not be necessarily exhibited elsewhere, like Nazi toys.\n\nTo my understanding, this is only a very small percentage of the total amount of toys that are available to be exhibited.  They have an actual museum curator who actually preserves and categorizes the pieces.  \n\nFor anyone that appreciates toys from their childhood, this place is a must-visit.  \n\nIf there is a day when we are back in Singapore, I will be visiting this museum again."
+        }
+      ],
+      "description": "The MINT Museum of Toys was founded in 2007 and till date remains the largest vintage toy museum in Asia with an ever-growing collection of 50,000 vintage toys and collectables including various types of: Action Figures Advertising Enamel Signs Confectionary Biscuit Tins First-edition Comic Books & Novels Newspaper & Photograph Archives Collectible Card & Board Games Clothings, Costumes & Accessories Movie Posters & Vinyl Records Bicycles & Pedal Cars The above is a fraction of what the museum collects and the collection hails from 40 over countries ranging specifically between 1840s to 1980s. 'MINT' as part of our brand name 'MINT Museum of Toys' acts as a abbreviation for our tagline Moment of Imagination and Nostalgia with Toys as well as represents 'mint condition' as all our vintage toys in our collection and on display are in its mint condition!",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d1452075-Reviews-MINT_Museum_of_Toys-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "26 Seah Street",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "188382",
+        "address_string": "26 Seah Street, Singapore 188382 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.296381",
+      "longitude": "103.85465",
+      "timezone": "Asia/Singapore",
+      "email": "info@emint.com",
+      "phone": "+65 8339 8966",
+      "website": "http://www.emint.com/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d1452075-MINT_Museum_of_Toys-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#158 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "158"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "274",
+      "review_rating_count": {
+        "1": "15",
+        "2": "19",
+        "3": "61",
+        "4": "93",
+        "5": "86"
+      },
+      "photo_count": "419",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d1452075-m66827-Reviews-MINT_Museum_of_Toys-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 2,
+              "time": "0930"
+            },
+            "close": {
+              "day": 2,
+              "time": "1830"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0930"
+            },
+            "close": {
+              "day": 3,
+              "time": "1830"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0930"
+            },
+            "close": {
+              "day": 4,
+              "time": "1830"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0930"
+            },
+            "close": {
+              "day": 5,
+              "time": "1830"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0930"
+            },
+            "close": {
+              "day": 6,
+              "time": "1830"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0930"
+            },
+            "close": {
+              "day": 7,
+              "time": "1830"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: Closed",
+          "Tuesday: 09:30 - 18:30",
+          "Wednesday: 09:30 - 18:30",
+          "Thursday: 09:30 - 18:30",
+          "Friday: 09:30 - 18:30",
+          "Saturday: 09:30 - 18:30",
+          "Sunday: 09:30 - 18:30"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Specialty Museums",
+              "localized_name": "Specialty Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622412",
+          "name": "City Hall"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "66"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "44"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "77"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "42"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "26 Seah Street",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "188382",
+        "address_string": "26 Seah Street, Singapore 188382 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Lim Bo Seng Memorial": [
+    {
+      "location_id": "3459826",
+      "name": "Lim Bo Seng Memorial",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/c8/3e/71/photo4jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/04/25/1e/a4/lim-bo-seng-memorial.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/19/c3/64/2e/lim-bo-seng-memorial.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/19/c3/63/f5/lim-bo-seng-memorial.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/19/c3/63/b3/lim-bo-seng-memorial.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Simple but interesting Memorial",
+          "text": "Sunday 20th October and we were walking to the Singapore Flyer along Quen Elizabeth Walk to Esplanade Park, where this Memorial is situated.\n\nThe Memorial is in the shape of a pagoda and is made of bronze, concrete and marble.\n\nThe Lim Bo Seng Memorial is a tribute to Major-General Lim Bo Seng, one of Singapore’s many war heroes during World War II."
+        },
+        {
+          "title": "A fairly simple memorial that will not leave you in awe.",
+          "text": "I came across the \"Lim Bo Seng Memorial\" whilst taking a walk through Esplanade Park.  It is a very simple memorial that acknowledges the sacrifice of Lim Bo Seng during his resistance fight against the Japanese in WW2.  Worth a look if passing but it will not leave you in awe that's for sure."
+        },
+        {
+          "title": "war hero",
+          "text": "this needs to be visited together with the other location in Macritchie Reservoir. a war hero who did everything he could for a place he called home."
+        },
+        {
+          "title": "Almost missed this little memorial",
+          "text": "Situated within the Esplanade Park, however we almost missed it. \n\nNice historical story of the background of Gen Lim Bo Seng. Do take the time to read the plaque"
+        },
+        {
+          "title": "another sombre point of interest in Esplande park",
+          "text": "another historical monument to add to your self walking tour. this memorial honours a resistance fighter of WW2"
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d3459826-Reviews-Lim_Bo_Seng_Memorial-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 Esplanade Drive Esplanade - Theatres On the Bay",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "038981",
+        "address_string": "1 Esplanade Drive Esplanade - Theatres On the Bay, Singapore 038981 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.28986",
+      "longitude": "103.85592",
+      "timezone": "Asia/Singapore",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d3459826-Lim_Bo_Seng_Memorial-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#514 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "514"
+      },
+      "rating": "3.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.5-66827-5.svg",
+      "num_reviews": "20",
+      "review_rating_count": {
+        "1": "0",
+        "2": "0",
+        "3": "12",
+        "4": "7",
+        "5": "1"
+      },
+      "photo_count": "34",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d3459826-m66827-Reviews-Lim_Bo_Seng_Memorial-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Monuments & Statues",
+              "localized_name": "Monuments & Statues"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622655",
+          "name": "Marina Centre"
+        },
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "5"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "11"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "2"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "1"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "1 Esplanade Drive Esplanade - Theatres On the Bay",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "038981",
+        "address_string": "1 Esplanade Drive Esplanade - Theatres On the Bay, Singapore 038981 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Universal Studios Singaporeâ„¢ Theme Park": [
+    {
+      "location_id": "2439664",
+      "name": "Universal Studios Singapore",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/e2/fe/30/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0a/3c/87/b6/the-lost-world.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0a/57/dd/bd/meet-diane-jurassic-park.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0a/57/dd/bb/the-cruisers.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0a/57/dd/ba/the-cruisers.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A magic place",
+          "text": "One of my dream bucket list. I’ve been wanting to come here since I was young, but somehow managed to be here when I’m older. This place is magical and always makes me feel young!"
+        },
+        {
+          "title": "Ride the Cylone Rollercoaster,  the wait is worth it.",
+          "text": "When we were there it wasn't that busy.  Although we opted for the Express pass some rides only had a 10 min waiting time.  Get there when it opens to avoid the crowds. It's  smaller than Japan and California,  but still worthwhile.  Best roller-coaster  - Cylone."
+        },
+        {
+          "title": "Great Day Out",
+          "text": "Was exceptionally clean and staff exceptionally hospitable, not large but can do comfortably in a full day.unfortunately several rides closed due to inclement weather"
+        },
+        {
+          "title": "Best family day",
+          "text": "USS is the best theme park to visit, the newly opened minionland was also so much fun. My kids were the most excited ones!!"
+        },
+        {
+          "title": "Good",
+          "text": "The place is full of great entertainment and fun, The express ticket as they say allows you to access everything without waiting in a queue but that is not true, the staff member outside informed us that there is two types of express ticket, one with exeption for some games where you have to wait in a ling queue and another express when you pay higher price so you access everything without waiting, then when we got inside that was not correct as in some games we were told that we cant use express ticket, and if you will go to repeat one game that you like then you cannot use the express ticket, it's only one time use,  also we had to pay for the dryer after we got wet with water spalsh game, so what's the use of paying extra for express ticket. Many people from different countries are visiting the place there should be a variety of global fast food restaurant, but there is not, also the drinks should be better and have vriety but all the of them sell the same juice every where there. Also one show at water world i missed it some years ago as the last show was at 3 pm, and last week this side was closed for maintenance which was disappointing. They need to have more seating areas with air condition so people can rest in between as the weather is so hot. The experience was overall good but a lot of dissappointments here and there."
+        }
+      ],
+      "description": "Singapore’s only movie-theme park features 24 rides and attractions, including a pair of dueling coasters that brush past one another in several near misses in their aerial combat. Thrill-seekers can choose between a coaster where they are seated or the other where riders are suspended. Exciting loops, sudden turns, breathtaking drops and thrilling near-collisions will make you scream your heart out. Dinosaurs, lemurs, ogres and Egyptian mummies add to the thrills and adventures.With 18 attractions created or redesigned for Singapore, Universal Studios Singapore™ promises an experience that you will not forget. Laughter and screams are heard around every corner, and lasting memories are made every day. Themed dining and shops are available. UNIVERSAL STUDIOS, UNIVERSAL STUDIOS SINGAPORE, Universal Globe logo, and all Universal elements and related indicia ™ & © Universal Studios. All Rights Reserved.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294264-d2439664-Reviews-Universal_Studios_Singapore-Sentosa_Island.html?m=66827",
+      "address_obj": {
+        "street1": "8 Sentosa Gateway",
+        "street2": "Resorts World Sentosa",
+        "city": "Sentosa Island",
+        "state": "Sentosa Island",
+        "country": "Singapore",
+        "postalcode": "098269",
+        "address_string": "8 Sentosa Gateway Resorts World Sentosa, Sentosa Island 098269 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "Island",
+          "name": "Sentosa Island",
+          "location_id": "294264"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.254",
+      "longitude": "103.824",
+      "timezone": "Asia/Singapore",
+      "email": "enquiries@rwsentosa.com",
+      "phone": "+65 6577 8888",
+      "website": "http://www.rwsentosa.com/en/attractions/universal-studios-singapore?utm_source=tripadvisor_uss&utm_medium=affiliates&utm_campaign=businesslistings",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294264-d2439664-Universal_Studios_Singapore-Sentosa_Island.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294264",
+        "ranking_string": "#1 of 29 things to do in Sentosa Island",
+        "geo_location_name": "Sentosa Island",
+        "ranking_out_of": "29",
+        "ranking": "1"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "20625",
+      "review_rating_count": {
+        "1": "628",
+        "2": "623",
+        "3": "2307",
+        "4": "6655",
+        "5": "10412"
+      },
+      "photo_count": "22557",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294264-d2439664-m66827-Reviews-Universal_Studios_Singapore-Sentosa_Island.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 19:00",
+          "Tuesday: 10:00 - 19:00",
+          "Wednesday: 10:00 - 19:00",
+          "Thursday: 10:00 - 19:00",
+          "Friday: 10:00 - 19:00",
+          "Saturday: 10:00 - 19:00",
+          "Sunday: 10:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "amusement_parks",
+          "localized_name": "Water & Amusement Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Water & Amusement Parks",
+          "localized_name": "Water & Amusement Parks",
+          "categories": [
+            {
+              "name": "Theme Parks",
+              "localized_name": "Theme Parks"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "186"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "4269"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "645"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "8942"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "3137"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "AmusementWaterParks"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        }
+      ],
+      "address": {
+        "street1": "8 Sentosa Gateway",
+        "street2": "Resorts World Sentosa",
+        "city": "Sentosa Island",
+        "state": "Sentosa Island",
+        "country": "Singapore",
+        "postalcode": "098269",
+        "address_string": "8 Sentosa Gateway Resorts World Sentosa, Sentosa Island 098269 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Singapore Science Centre": [
+    {
+      "location_id": "446423",
+      "name": "Science Centre Singapore",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/5a/ab/d9/where-science-comes-alive.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/03/42/dd/ca/triple-the-adventure.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/18/0f/c5/e4/dinoquest-exhibition.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/5a/ab/c7/untame.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-p/18/19/0e/1e/i-m-a-science-explorer.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Basic science for kids",
+          "text": "Visiting for the first time with my boy, and he was happy. We learned a lot of basic science knowledge about electricity, fire, and outer space. The exhibit also featured a mobile from Western Australia and its indigenous cultur"
+        },
+        {
+          "title": "STEM science for the cognoscenti in a galaxy of focus exhibits that challenge and entertain. Plan to return.",
+          "text": "Review of the Science Centre Singapore, Jurong East, Singapore\nIt was a first visit for the two of us – in Singapore for the week – but our wards for the day (three primary school-age kids) had been before and were particularly keen to runaround in the kid’s water park to one side of the main building. For us this was best mid-afternoon and after 3-4 hours of exploring the complex and multi-disciplinary exhibits available that challenged the more inquisitive (and particularly those STEM kids of secondary school age plus).\n\nHow could you not appreciate the planning, design and investment that had been made during almost 50 years that have evolved into the modern-day Science Centre. This is Singapore conceptualizing the country/people into the future – challenging those new generations of kids that are always coming through.\n\nFocusing on play, exhibition and knowledge-sharing the Centre provides a mix of demonstrations, print information/wallboards/notices, self-challenges and more that apply to adults and kids alike in more than a couple of dozen separate exhibition-focused sub-centres. Whether exploring the visual images of you and your fellow travellers in the maze of mirrors (wherein you’re provided with a short plastic tube that you hold in front of you to prevent you  turning into your own reflection); exploring your personal phobias/fears (you being buried alive, you addressing a public meeting, your phobias – ghosts, insects, reptiles, tunnels, school, etc.); and many, many more – to numerous to cover here.\n\nYou and your personal waste was a novel focus - this is you understanding what happens to the food that you eat, how/where you process it internally and, crucially, how you excrete those parts that are of little/no value to you. Therein is focus upon those familiar bodily functions in language/diagrams that are easy to follow. In a word or two … how much do you understand ‘Poo’ at both personal and public level? You may be surprised of just how little most of us know about the reality/mechanics of poo (inside and outside the body).\n\nAt key times during the day the Centre offered public demonstrations of ‘fire’ and ‘electricity.’ This came within well-established/protected equipment/environments that began with a brief synopsis of the concepts involved, followed by the security issues that apply (i.e. the personal risks that apply to public demonstrations of his kind, and requirements for crowd control/escape should unexpected risks/issues arise). We were informed that electrical discharge across open space exemplifies lightning and/or those historical scientific R&D investigations that, 200 years later, may seem novel/dangerous to us – but which have enabled the modern world to understand, apply and implement programs that currently suggest that solar power as a source of energy/electricity will eventually come to dominate human development everywhere (and, subsequently, help stabilize and/or reverse global climate warming).\n\nSo, our visit helped confirm the raison d'etre of the Science Centre, but it also re-confirmed that you’d need to make several visits to explore the entire range of focuses, sub-centres, concepts, entertainment and more available. We just ran out of time, etc. and completely by-passed Tinkering, Climate Change, Earth Alive, Embracing Ageing, Light Fantastic, Mind’s Eye, Laser Maze, Ecogarden, Kinetic Garden, etc. What we did capture, however, was the full extent of the delightful play available in Waterworks – the kid’s water park – the highlight of our visit.\n\nThe water exhibits may have helped stimulate those young brains, but it was the joie de vivre of the kids in the pleasure of running around in the water pools, showers, jets, curtains and falling water that really came across well. The actual science, of course, was entirely beyond them - how much water can you personally support in tubes; how the clock in the tower also records wind direction/velocity and rainfall; how rainbows are formed, etc.\n\nIt should also be said that the design/concept of the original R&D water facilities reflect an investment made 40-50 years ago – and they looked tired; many appeared defunct and/or were no longer working – the rainbow/umbrella/compass, the twin water buckets at the top of the clock tower (which no longer filled/tipped – and presumably powered the clock), etc. Whatever, it was all well-over the heads of our three youngsters who would rather be playing on the large seesaw (which dunked them in the water each cycle) than explore the science available (or, the reality, not available). All great fun then.\n\nAnd it’s not enough to appreciate the Science Centre of the day, but to note that a new one is in the pipeline (as reported for 2027). It’s destined to be next to the existing Centre and will comprise five inter-locking rectangular buildings over-looking Jurong Lake. If this date is met it will represent the 50th anniversary of the opening of the Centre. Well done everyone.\n\nAnd here’s some user-experience worth noting … travel by MRT to Jurong East station and then walk to Centre. Follow Google maps? Sure, easy … easy it was not. Building development around the station/neighbourhood was/is challenging. There were no signs directing those on foot. Mind you, it sets you up for the Science Centre. That was confusing too.\n\nPeter Steele\n06 November 2024"
+        },
+        {
+          "title": "Worth Every $$$$ Spent!!",
+          "text": "We just finished 3 hours at the Science Centre, and we absolutely could have spent another hour as we didn’t even get through it all! Opens at 10am, so I say get there for opening to have the whole day. They have a huge restaurant on site, I cannot comment on food as we didn’t eat while there. \n\nWorth every $$$ spent, this place is HUGE and so much fun, for kids and adults alike. Me & my hubs and had as much fun, if not more than our 11 year old. So much more to do that I expected, it exceeded all my expectations. \n\nTake your time to walk through, watch the shows, and try everything! Our favourite was the lightening show at 12pm, the scary spooky house and the mirror maze. \n\nThey do have a water play section, so I recommend to pack bathers for the kids if they want to get wet after. Upon exit is a huge shop with lots of science kits and science goodies if you want to continue the science fun at home."
+        },
+        {
+          "title": "A day of infotainment",
+          "text": "This visit brought back so many memories to where I had last visited it as a kid!  My two kids were first unsure how it would turn out to be, they started complaining that it was too childish for them (aged 12 and 15)  and gradually as they kept discovering all these creative and educational exhibits with a fun twist to them, they were in awe and didn't want to leave! However we also visited the Omni theatre and that was a huge disappointment. Not worth the money. The technology is in place but the movie options were hopeless - not at all entertainment in any kind."
+        },
+        {
+          "title": "Very unscientific.",
+          "text": "\"science\" centre. They have no regard for actual science. More like pseudo science centre. This is not a place you go to if you want to be inspired by facts and actual science."
+        }
+      ],
+      "description": "Science Centre Singapore is dedicated to the promotion of science and technology among students and members of the public. As a leading Science Centre in the region, it has twelve exhibition galleries with more than 1,000 interactive exhibits.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d446423-Reviews-Science_Centre_Singapore-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "15 Science Centre Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "609081",
+        "address_string": "15 Science Centre Road, Singapore 609081 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.33317",
+      "longitude": "103.73564",
+      "timezone": "Asia/Singapore",
+      "email": "feedback@science.edu.sg",
+      "phone": "+65 6425 2500",
+      "website": "http://www.science.edu.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d446423-Science_Centre_Singapore-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#77 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "77"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "785",
+      "review_rating_count": {
+        "1": "30",
+        "2": "42",
+        "3": "113",
+        "4": "279",
+        "5": "321"
+      },
+      "photo_count": "641",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d446423-m66827-Reviews-Science_Centre_Singapore-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1700"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 17:00",
+          "Tuesday: 10:00 - 17:00",
+          "Wednesday: 10:00 - 17:00",
+          "Thursday: 10:00 - 17:00",
+          "Friday: 10:00 - 17:00",
+          "Saturday: 10:00 - 17:00",
+          "Sunday: 10:00 - 17:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Science Museums",
+              "localized_name": "Science Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622401",
+          "name": "Jurong Lake"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "5"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "52"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "16"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "448"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "48"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "15 Science Centre Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "609081",
+        "address_string": "15 Science Centre Road, Singapore 609081 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Fuk Tak Chi Museum & Places of Interest": [
+    {
+      "location_id": "317429",
+      "name": "Fuk Tak Chi Museum",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/13/fb/9e/2e/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0d/fc/65/75/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/69/e9/43/fuk-tak-chi-museum.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/69/e9/3b/fuk-tak-chi-museum.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/69/e9/33/fuk-tak-chi-museum.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Surprising find in an alley",
+          "text": "Stumbled upon this little 'museum' while walking in Far East Square. Part of the Amoy Hotel, it records the arrival of the early Chinese immigrants at Telok Ayer in the little miniature which shows the coolies, their work and living quarters. It's actually part of an old temple but some artefacts illustrate the courtyard, well, costumes and utensils of that time. Names of significant people in the community, their efforts and donations are also etched on the walls. It's free, visitors are welcome and the young lady customer service officer was most gracious and helpful.\nA nice little unexpected find in the quietness of Covid times when the streets and stalls aren't well-patronized or fully functioning."
+        },
+        {
+          "title": "I wouldn't call it a museum...",
+          "text": "Its more like the lobby of the Amoy Hotel. If you look at the pictures on this site...that's all there is. One room with a couple of exhibits. Less than five minutes and we'd seen it all.\nIf your passing by pop in and have a look, but don't go out of your way like we did to visit."
+        },
+        {
+          "title": "Small Museum At The Entrance To The Amoy Hotel",
+          "text": "This is a small museum  in what was the oldest Chinese temple in Singapore built around 1824. In 1994 it was turned into a museum and it is now the entrance to the Amoy Hotel.It has some interesting exhibits and worth a  quick look as you walk Telok Ayer Street."
+        },
+        {
+          "title": "Interesting side step into history ",
+          "text": "This was one of the oldest Chinese temples in Singapore, built in 1824 by Hakka and Cantonese immigrants, dedicated to the Chinese deity, Tua Pek Kong (God of Wealth), who is worshipped by both Confucianists and Taoists. In the early 1990s the temple fell into disrepair and was handed over to the government. In 1998, the building was restored and converted into a street museum with artifacts on the lives of early Chinese migrants in Singapore. It also forms part of the Amoy Hotel lobby. Open seven days 10am-10pm, free entry."
+        },
+        {
+          "title": "Fascinating little museum",
+          "text": "One of Singapore's oldest temples, that was converted into a little museum, free entry for all. Provides an interesting snapshot of how life was like in colonial Singapore in the 1800s-1900s. The building itself is lovely to look at, with beautiful details. Great place to relax with comfortable chairs around."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d317429-Reviews-Fuk_Tak_Chi_Museum-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Far East Square",
+        "street2": "Telok Ayer Street",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "",
+        "address_string": "Far East Square Telok Ayer Street, Singapore Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.281",
+      "longitude": "103.84779",
+      "timezone": "Asia/Singapore",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d317429-Fuk_Tak_Chi_Museum-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#407 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "407"
+      },
+      "rating": "3.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.5-66827-5.svg",
+      "num_reviews": "27",
+      "review_rating_count": {
+        "1": "1",
+        "2": "1",
+        "3": "9",
+        "4": "12",
+        "5": "4"
+      },
+      "photo_count": "96",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d317429-m66827-Reviews-Fuk_Tak_Chi_Museum-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Specialty Museums",
+              "localized_name": "Specialty Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622374",
+          "name": "Outram"
+        },
+        {
+          "location_id": "15622676",
+          "name": "Central Business District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "6"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "12"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "0"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "5"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "Far East Square",
+        "street2": "Telok Ayer Street",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "",
+        "address_string": "Far East Square Telok Ayer Street, Singapore Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Katong Antique House Singapore: Peranakan Heritage": [
+    {
+      "location_id": "317437",
+      "name": "Katong Antique House",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/19/81/4a/26/img-20191005-105042-largejpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/6a/12/89/katong-antique-house.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/14/05/c8/katong-antique-house.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/f0/48/01/photo5jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/f0/48/00/photo4jpg.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Peranakan culture",
+          "text": "After being closed for renovations for months, we were happy to finally be able to visit the Katong Antique House. Our guide Angeline was very knowledgeable and made it very personal and entertaining. The tour takes about 45 minutes and costs 15 SGD per person, it’s worth every cent! "
+        },
+        {
+          "title": "Door Opens To A Surprise!",
+          "text": "The house is situated in Katong, a Straits Chinese enclave, right next to Holy Family Church.\nA great place to  experience how Straits Chinese used to live. Many thanks to Eric who described every part of the house in detail so passionately. This 'museum' was started by Mr. Peter Wee, a well-respected doyen of Peranakan culture, who spared no effort in collecting Peranakan antiques handed down by his ancestors and other Straits Chinese. Do call to make an appoinment to visit."
+        },
+        {
+          "title": "A Peek Into Peranakan Culture",
+          "text": "This beautiful little museum of sorts reopened earlier this year. It is a lovely place to visit. Eric our guide was so patient and informative telling us about different Peranakan items and also the history of what constitutes Peranakan culture etc. Spent a lovely hour here. Lots of beautiful antiques, earthen ware, gadgets, shoes, clothing etc to be explored. Would love to see the upstairs open up to what Peranakan bedrooms looked like."
+        },
+        {
+          "title": "Lovely beautiful residence",
+          "text": "So this is the Residence of local Singaporean, built about 1920's. Looking good with colorfull fasad, and nice pedestrian.\nTIPs: visit around 8AM or after 5PM, and dont forget your umbrealla. Its pretty Hot. "
+        },
+        {
+          "title": "Just reopened",
+          "text": "Sadly the owner passed away last year.  We happened to be by chance walking by when we overheard another person contacting a house representative to confirm their arrival for their appointment.  Fortunately for us the representative allowed us to enter along with the  other two (who had pre arranged entry).  While not a full tour, we only saw the bottom floor (entry way, dinning table, stairs foyer and the kitchen) - thus was still a fascinating glimpse into an hundred year old terrace House filled with Peranankan goods and photos of a bygone era.  Appreciate the hospitality of the house representative.  Thanks. "
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d317437-Reviews-Katong_Antique_House-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "208 E. Coast Rd.",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "",
+        "address_string": "208 E. Coast Rd., Singapore Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.30727",
+      "longitude": "103.90713",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6345 8544",
+      "website": "http://www.yoursingapore.com/editorials/meeting-peter-wee-of-the-east-side-neighbourhood-katong.html",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d317437-Katong_Antique_House-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#341 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "341"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "34",
+      "review_rating_count": {
+        "1": "2",
+        "2": "3",
+        "3": "7",
+        "4": "11",
+        "5": "11"
+      },
+      "photo_count": "46",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d317437-m66827-Reviews-Katong_Antique_House-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Historic Sites",
+              "localized_name": "Historic Sites"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622354",
+          "name": "Marine Parade"
+        },
+        {
+          "location_id": "15622462",
+          "name": "Katong"
+        },
+        {
+          "location_id": "7291626",
+          "name": "Joo Chiat"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "2"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "4"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "6"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "4"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "9"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "208 E. Coast Rd.",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "",
+        "address_string": "208 E. Coast Rd., Singapore Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Chinese Garden Singapore": [
+    {
+      "location_id": "379346",
+      "name": "Chinese and Japanese Gardens",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/14/af/81/84/lake.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/d7/28/c7/img-20190602-205909-841.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/64/07/78/a-new-garden-with-a-variety.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/64/07/74/a-new-garden-with-a-variety.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/37/5d/39/chinese-and-japanese.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A real letdown",
+          "text": "I was excited to visit the Japanese Garden again, since it had been closed for 5 years for renovation. But the trip was a complete letdown. Most of the elements that had given the garden its character are gone - the Karezansui dry garden at the entrance now just looks like a random pile of rocks, there is no more cloud pruning, most of the red bridges have been removed, the beautiful stone lantern valley is gone, the Kusari-doi rain chain is gone, etc. The garden just looks like any other park in Singapore. Why still call it a Japanese garden if it no longer reflects that culture and tradition? There are also numerous signs around the garden informing visitors of the science behind various aspects of the garden. That's all very well, but how about some culture as well?"
+        },
+        {
+          "title": "Experience was awesome one should must visit",
+          "text": "The views were awesome clicked \"pictures \nThe visit to the Chinese and Japanese gardens was amazing. The lush greenery, tranquil ponds, and beautiful landscapes made it a peaceful and serene experience. The blend of traditional architecture and nature was truly captivating, offering a perfect escape to relax and connect with nature.\""
+        },
+        {
+          "title": "Great green space",
+          "text": "The mrt stop is Chinese Garden followed by a short sheltered walk to the gate with the view of the impressive pagoda.  The rejuvenated gardens have many new features such as the Cascading Creek, Water Lily ponds with with many different species of water lilies, Bonsai Garden, Sunken Garden etc. These two gardens are connected to Jurong Lake Gardens by bridges so it is a huge place to explore. Entry is free. There is another gate near the water lily pond which is nearer to Jurong Bus Interchange. Breathing Gallery provides a cool air-conditioned environment to look at the terrariums and aquariums. Best enjoyed in cool weather."
+        },
+        {
+          "title": "Worth making the effort to visit.",
+          "text": "Worth making the effort to visit. It is slightly off the main tourist track but is easily accessible by the MRT. The Chinese Garen MRT station is a few minutes walk away and as there is some construction work going on make sure you follow the signs. The gardens are well laid out and entrance is free. The Bonsai collection is impressive and is a must see! Across the bridge is the Japanese Garden with a simplicity of design, as you would expect. Highly recommended visit."
+        },
+        {
+          "title": "STILL CLOSED SEPT 2023",
+          "text": "See above  ......................\n\n................................................................"
+        }
+      ],
+      "description": "- Temporarily closed The stunning colors of the plants and rock formations in the Chinese Garden contrast with the thought-provoking Japanese Garden.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d379346-Reviews-Chinese_and_Japanese_Gardens-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 Chinese Garden Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "619795",
+        "address_string": "1 Chinese Garden Road, Singapore 619795 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.33836",
+      "longitude": "103.72662",
+      "timezone": "Asia/Singapore",
+      "email": "juronglakegardens@nparks.gov.sg",
+      "phone": "+65 1800 471 7300",
+      "website": "https://www.nparks.gov.sg/juronglakegardens/who-we-are/jurong-lake-gardens",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d379346-Chinese_and_Japanese_Gardens-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#56 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "56"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "752",
+      "review_rating_count": {
+        "1": "10",
+        "2": "16",
+        "3": "92",
+        "4": "316",
+        "5": "318"
+      },
+      "photo_count": "1309",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d379346-m66827-Reviews-Chinese_and_Japanese_Gardens-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0600"
+            },
+            "close": {
+              "day": 1,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0600"
+            },
+            "close": {
+              "day": 2,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0600"
+            },
+            "close": {
+              "day": 3,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0600"
+            },
+            "close": {
+              "day": 4,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0600"
+            },
+            "close": {
+              "day": 5,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0600"
+            },
+            "close": {
+              "day": 6,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0600"
+            },
+            "close": {
+              "day": 7,
+              "time": "2200"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 06:00 - 22:00",
+          "Tuesday: 06:00 - 22:00",
+          "Wednesday: 06:00 - 22:00",
+          "Thursday: 06:00 - 22:00",
+          "Friday: 06:00 - 22:00",
+          "Saturday: 06:00 - 22:00",
+          "Sunday: 06:00 - 22:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Gardens",
+              "localized_name": "Gardens"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622401",
+          "name": "Jurong Lake"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "10"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "190"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "139"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "146"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "118"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "1 Chinese Garden Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "619795",
+        "address_string": "1 Chinese Garden Road, Singapore 619795 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "East Coast Park Singapore": [
+    {
+      "location_id": "317426",
+      "name": "East Coast Park",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/19/0f/b9/07/west-coast-park.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/6c/9c/c0/east-coast.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/44/d8/21/east-coast-park.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1d/72/ff/37/after-sunset-at-east.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/ff/17/67/beach.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Beautiful park by the seaside",
+          "text": "This park is wonderful and very well utilised by Singaporeans. Many activities for children as well as cafes and pet and dog grooming and dog training all by the seaside.\n\nWe actually had a late lunch at a Turkish cafe in the Park. then proceeded to walk through the park and sat down by the sea. The sea even though it is full of shipping tankers, it is still just wonderful to look out to the vast expanse of the ocean. It is so calming. We spend a relaxing while just watching the sea  before continuing our walk. There is a lot of natural bushland as well with warnings about native monkeys. We did not see any. Just lots of happy Singaporeans enjoying the park.\n\nIf you are in the area of Marine Parade or nearby do drop by for an hour or two. You will enjoy it. There is even a Starbucks for some take away coffee while you enjoy the scenery."
+        },
+        {
+          "title": "Eastern Surprise",
+          "text": "Just a short walkaway (or if limited in time bicycle rental is available) from Changi Airport is East Coast Park well worth a visit if you have a few hours to relax before your flight or even a stopover. From Terminal 4 you can saunter first through Jurassic Changi Mile first observing the dinosaur statutes before arriving 20 minutes later at the Park entrance, fresh air and sea breeze greet you with well kept, tree lined and plant laden gardens. After around 20 minutes walking you come to small beach with bbq facilities and toilets /shower facilities. Depending how long you have, you can walk for hours actually arriving in Singapore Centre simply follow the well informed pathway and be impressed by the facilities and amenities including restaurants as you meander your way through the park."
+        },
+        {
+          "title": "Overall, a great facility.",
+          "text": "Excellent for jogging, and if the weather isn't cloudy, you might be able to see the dawn or sunset.\n\nMarine Cove has a large playground and delicious meals. An excellent leisure area for cyclists, families, and other people.\n\nHowever, because there is only one route (route 401) that travels through East Coast Park, getting there by public bus might be a little challenging."
+        },
+        {
+          "title": "okay",
+          "text": "East Coast Park is the perfect spot to relax and unwind! Beautiful beaches, great cycling paths, and plenty of food options. A peaceful escape from the city."
+        },
+        {
+          "title": "Ruined by inconsiderate crowds",
+          "text": "Used to be a great place to cycle, relax and fish. Now there's litter and noise pollution everywhere. Still a nice place if one avoids Fridays-Sundays completely. Best to go on a weekday morning (but not Monday mornings, when the weekend trash hasn't been cleared yet)."
+        }
+      ],
+      "description": "The city’s most popular stretch of beach always buzzes with activity – even when it’s not playing host to the wide spectrum of sporting events that grace its shores regularly, like the Singapore Marathon and Xtreme Championship.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d317426-Reviews-East_Coast_Park-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Along East Coast Parkway and East Coast Park Service Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "455486",
+        "address_string": "Along East Coast Parkway and East Coast Park Service Road, Singapore 455486 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.300784",
+      "longitude": "103.912186",
+      "timezone": "Asia/Singapore",
+      "website": "https://www.nparks.gov.sg/gardens-parks-and-nature/parks-and-nature-reserves/east-coast-park",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d317426-East_Coast_Park-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#43 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "43"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "1252",
+      "review_rating_count": {
+        "1": "13",
+        "2": "12",
+        "3": "140",
+        "4": "526",
+        "5": "561"
+      },
+      "photo_count": "862",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d317426-m66827-Reviews-East_Coast_Park-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "outdoor_activities",
+          "localized_name": "Outdoor Activities"
+        },
+        {
+          "name": "activities",
+          "localized_name": "Activities"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Beaches",
+              "localized_name": "Beaches"
+            },
+            {
+              "name": "Parks",
+              "localized_name": "Parks"
+            }
+          ]
+        },
+        {
+          "name": "Outdoor Activities",
+          "localized_name": "Outdoor Activities",
+          "categories": [
+            {
+              "name": "Beaches",
+              "localized_name": "Beaches"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622354",
+          "name": "Marine Parade"
+        },
+        {
+          "location_id": "15622460",
+          "name": "East Coast"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "39"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "208"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "134"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "337"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "232"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "Along East Coast Parkway and East Coast Park Service Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "455486",
+        "address_string": "Along East Coast Parkway and East Coast Park Service Road, Singapore 455486 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Fort Canning Park": [
+    {
+      "location_id": "324755",
+      "name": "Fort Canning Park",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-p/1c/d3/0a/14/fort-canning-park.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/48/25/79/fort-canning-centre-picture.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/48/25/6f/fort-gate.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/48/25/78/trees-in-fort-canning.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/18/a0/86/27/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A fabulous greenspace",
+          "text": "Huge Park whose history is intertwined with that of Singapore and includes kings and colonialists and war and surrender. There are historic buildings and leftover relics here, but you are aware of more plants, flowers and shrubs that create much more green space. Events are held up on the hill. Be careful of the steep sets of steps but there are nearby benches"
+        },
+        {
+          "title": "Great place to visit!",
+          "text": "It is possible to learn a considerable amount about the history of Singapore from Fort Canning. It’s a great place to visit, burn calories and relax. The one drawback for anyone with mobility problems is the many steps within the park. There’s certainly plenty to see with a very good museum, Raffles house and various military buildings one of which is now an hotel.\nJust wandering around through the magnificent trees and grounds makes you forget that you are  in the centre of the busy city state. There’s plenty of places to sit in the shade and when refreshment is called for, the Le Jardin cafe serves good food and snacks.\nThere’s a MRT station within walking distance. Toilets are available in the museum and Le Jardin."
+        },
+        {
+          "title": "Great park for a stroll",
+          "text": "Our hotel was near here so we visited twice. Well signed to walk around. Trees labelled. Nice paths. Sadly it rained for much of our visit but still loved it. Sadly we were not there at the right time to go to the Battle Box"
+        },
+        {
+          "title": "Beautiful park.",
+          "text": "Beautiful park, lots to see. Lots of walking and steps. The museum is very interesting and a great place to cool down. Take water as it’s very hot."
+        },
+        {
+          "title": "Amazing location for wildlife, green space and nature",
+          "text": "This is a stunning place of scenery, wildlife and nature. I could have easily got lost in here and spent the whole day here. There was a great mix of greenery and nature wildlife roaming around. Wasn't overly busy and there was plenty of shade and places to sit for when the sun got too much. A wee bit hilly but not unpleasant or unbearable if you are reasonably fit. Great for photos and to have a digital detox and just within nature."
+        }
+      ],
+      "description": "Fort Canning Park is one of Singapore's most historic landmarks. It has witnessed Singapore's golden age, when Malay Kings ruled from its peak, and watched as the island transformed from a sleepy fishing village into a vibrant trading hub in the 19th century. During World War II, the hill was instrumental in Singapore's war efforts with numerous military buildings located there. One of these buildings was the Fort Canning Bunker or Battle Box, where the decision to surrender Singapore to the Japanese was made by the British. Many war relics from Singapore's colourful history have survived on the hill and are still visible today.Although the hill has since lost its imposing stature, its distinctive charm still remains. The lush lawns draw picnics, concerts, theatre productions and festivals, while weddings, parties and gatherings are a regular sight in the park's elegant indoor function rooms. Visit the park today and experience the tranquillity once enjoyed by the Malay royals of yore.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d324755-Reviews-Fort_Canning_Park-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "River Valley Rd",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179038",
+        "address_string": "River Valley Rd, Singapore 179038 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.292143",
+      "longitude": "103.8458",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 1800 471 7300",
+      "website": "http://www.nparks.gov.sg/fortcanning",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d324755-Fort_Canning_Park-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#28 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "28"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "1160",
+      "review_rating_count": {
+        "1": "5",
+        "2": "14",
+        "3": "126",
+        "4": "542",
+        "5": "473"
+      },
+      "photo_count": "2277",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d324755-m66827-Reviews-Fort_Canning_Park-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0000"
+            },
+            "close": {
+              "day": 1,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0000"
+            },
+            "close": {
+              "day": 2,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0000"
+            },
+            "close": {
+              "day": 3,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0000"
+            },
+            "close": {
+              "day": 4,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0000"
+            },
+            "close": {
+              "day": 5,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0000"
+            },
+            "close": {
+              "day": 6,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0000"
+            },
+            "close": {
+              "day": 7,
+              "time": "2359"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 00:00 - 23:59",
+          "Tuesday: 00:00 - 23:59",
+          "Wednesday: 00:00 - 23:59",
+          "Thursday: 00:00 - 23:59",
+          "Friday: 00:00 - 23:59",
+          "Saturday: 00:00 - 23:59",
+          "Sunday: 00:00 - 23:59"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Parks",
+              "localized_name": "Parks"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622372",
+          "name": "Museum"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622418",
+          "name": "Fort Canning"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "32"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "335"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "230"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "186"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "137"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "River Valley Rd",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179038",
+        "address_string": "River Valley Rd, Singapore 179038 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Kusu Island, Singapore": [
+    {
+      "location_id": "317438",
+      "name": "Kusu Island",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0d/52/40/b1/nice-view-of-the-temple.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/f5/f5/0d/kusu.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-p/17/69/5c/07/photo8jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/16/44/b5/d9/en-haut-du-datok-kong.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/16/44/b5/40/terrasse.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Nice temple, shrine, beaches - all in a small island next to Singapore",
+          "text": "Very cute small island with a Chinese Da Bo Gong temple, dedicated to turtle (\"Kusu\" = turtle in mandarin) that saved sailors, and keramat, a Malay shrine at the top of the hill. Along the small island, there are pretty nice beaches too, popular for locals."
+        },
+        {
+          "title": "A Serene Escape to Paradise: Kusu Island, Singapore",
+          "text": "Kusu Island is an exquisite gem nestled within Singapore's Southern Islands, and it offers a breathtaking blend of natural beauty, tranquility, and cultural significance. My recent visit to this enchanting destination left me awestruck, and I can't wait to share my experience."
+        },
+        {
+          "title": "Marina South Ferries’ worker in Kusu island is suck, terribly lack of courtesy and education.",
+          "text": "Marina South Ferries’ worker in Kusu island is suck, terribly lack of courtesy and education(equal 0). Screaming and insulting the guests."
+        },
+        {
+          "title": "Small island, whike endless line of ships going right next to it",
+          "text": "Unless you are going with purpose of visiting temple - absolutely  nothing to do. You can find better beach in Singapore proper."
+        },
+        {
+          "title": "Well maintained chinese temple",
+          "text": "We came here on 11 July 22, PH - Hari Raya Haji. The pier is located v near Marina South Pier mrt. \n\nWe bought the ferry tickets through klook with a discount n gong char voucher. Definitely worth the deal. The ferry is almost full at the 9am departure.  We follow the itinerary and visit st John Island as first stop for about 15-20 mins n then took the nxt ferry to Kusu Island.\n\nThere was a fire few months ago at the Hindu temple up the hills but the stairs was cordoned off on day of visit. \n\nThe Chinese temple was not crowded n looks well maintained.  We pray n make donations. The potted plants in the temple are beautiful. Not much people at the temple. We enjoyed the peaceful atmosphere, many sparrows, trees  waves, breezes.... away from the 😠 city life.\n\nYou need to bring your own food n water if u going to visit these islands."
+        }
+      ],
+      "description": "In addition to its wealth of heritage sites, Kusu Island is also a visitors’ favourite thanks to its picturesque lagoons, clean beaches and varied animal life.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d317438-Reviews-Kusu_Island-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Kusu Island",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "000704",
+        "address_string": "Kusu Island, Singapore 000704 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.2237",
+      "longitude": "103.85889",
+      "timezone": "Asia/Singapore",
+      "website": "http://www.yoursingapore.com/content/traveller/en/browse/see-and-do/nature-and-wildlife/island-retreat/kusu-island.html?TAHotelCode=153",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d317438-Kusu_Island-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#226 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "226"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "118",
+      "review_rating_count": {
+        "1": "4",
+        "2": "7",
+        "3": "29",
+        "4": "44",
+        "5": "34"
+      },
+      "photo_count": "348",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d317438-m66827-Reviews-Kusu_Island-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Islands",
+              "localized_name": "Islands"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "1"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "23"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "21"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "15"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "30"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "Kusu Island",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "000704",
+        "address_string": "Kusu Island, Singapore 000704 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Jurong Bird Park, Singapore: Attractions & Things to Do": [
+    {
+      "location_id": "21501698",
+      "name": "Jurong Hill Park",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/5d/48/32/view.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/8f/5e/78/photo3jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/8f/5e/77/photo2jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/8f/5e/76/photo1jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/8f/5e/75/photo0jpg.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "normal hill park",
+          "text": "A better time to visit there is the first opening of the weekday when it opens every Thursday, particularly for people who, like me, wish to avoid enormous crowds. It is also a perfect opportunity for photographers to snap shots simply and freely as the birds and landscapes will not be obstructed or impeded by people. When it opens every Thursday, the best time to go is the first opening of the weekday. Moreover, there are less people in the area, both locals and tourists.\n"
+        },
+        {
+          "title": "Nice Place",
+          "text": "It is highly suggested that you visit this location with the birds, and it is recommended that you purchase a meal activity and make a reservation in advance. The birds are quite close, and they are adorable.\n"
+        },
+        {
+          "title": "View isn’t good",
+          "text": "It’s an additional place you can go after visiting Jurong Bird Park if you drive. The view from the observation deck isn’t that great. Trees are blocking the view."
+        },
+        {
+          "title": "First Visit To the Hill",
+          "text": "Nice view from the tower and enjoyed it. Although it is so closed to the Jurong Bird Park, only few visitors there.Used to have one restaurant there and now already gone. \nVisitors could take bus service 194 from Boon Lay Interchange and alight at the bus stop of Jurong Bird Park and walk all the way up to the hill."
+        },
+        {
+          "title": "A quiet oasis with a view",
+          "text": "Jurong Hill is 60 m high and Jurong Town Corporation  has converted it into a park with its famous  Look Out Tower.  It was opened in 1970 and a visit to Jurong Hill Park feels like a step back in time.  It definitely reminded me of my younger days when a visit here was combined with a visit to the Jurong Bird Park which is next to it on the western side of the hill.\nThe road leading to the park has a gentle incline with lots of greenery.  Especially outstanding is the large bush of Simpoh Air with its freshly bloomed yellow flowers.\nAt the first level , there are the carpark,  toilet facilities and a small landscaped garden with plants such as poinsettia.  There used to be a restaurant here at this level but it is now closed.  \nThe Look Out Tower  can be reached by  another flight of stairs up to the higher level or a walk up the slope to get to it.  Beside the Look Out Tower is the Garden of Fame with 30 trees planted by foreign dignitaries and heads of states from 1969 to 1984.\n\nThe first tree was planted by Princess Alexandra of the United Kingdom in 1969 and the last tree was planted by Singapore’s economic advisor Dr Albert Winsemius in 1984.\n\nOthers who have planted trees here include Queen Elizabeth II, Deng Xiaoping and Singapore’s President Benjamin Sheares. The plaques at the base of each tree provide informations on the VIP and the dates of their visit.  There is also another newer Garden of Fame on the grounds of Jurong Town Hall as the space on Jurong Hill Park ran out.\n\nThe Look Out Tower  has broad ramps which spiral three levels upwards.  The top of the Look Out Tower has decorative stained glass set into the ceiling.\nAs we went up the ramps,  the view of Jurong Island in the distance unfolded.  We also saw unique fern-like trees with markings on its trunks which resemble lips.  \n\nWe took bus 194 from Boon Lay Interchange to get here.  The bus was an express one and we alighted at the first stop along Jalan Ahmad Abrahim.  Alternatively one can walk along the Jurong Park Connector from Jurong Central Park (opposite to Boon Lay Mrt Station) to get here.\nWe actually visited here after exploring the Raffles Marina Lighthouse next to the Tuas Link Mrt Station in the morning. We packed our lunch from Jurong Point and had a mini picnic at Jurong Hill Park.  It was a lovely visit exploring the gem spots in  industrial Jurong."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d21501698-Reviews-Jurong_Hill_Park-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 Jurong Hill",
+        "street2": "Along Jalan Ahmad Abrahim",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "",
+        "address_string": "1 Jurong Hill Along Jalan Ahmad Abrahim, Singapore Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.32077",
+      "longitude": "103.70613",
+      "timezone": "Asia/Singapore",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d21501698-Jurong_Hill_Park-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#404 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "404"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "6",
+      "review_rating_count": {
+        "1": "0",
+        "2": "0",
+        "3": "1",
+        "4": "3",
+        "5": "2"
+      },
+      "photo_count": "32",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d21501698-m66827-Reviews-Jurong_Hill_Park-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Parks",
+              "localized_name": "Parks"
+            },
+            {
+              "name": "Gardens",
+              "localized_name": "Gardens"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622344",
+          "name": "Boon Lay"
+        },
+        {
+          "location_id": "15622573",
+          "name": "Liu Fang"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "1"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "0"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "3"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "0"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "1 Jurong Hill",
+        "street2": "Along Jalan Ahmad Abrahim",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "",
+        "address_string": "1 Jurong Hill Along Jalan Ahmad Abrahim, Singapore Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "HortPark": [
+    {
+      "location_id": "2344355",
+      "name": "Hort Park",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/03/c4/12/ae/hort-park.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/77/71/b4/hortpark.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0f/6d/cf/bc/espalier-garden.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/d4/e0/fe/hort-park.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/05/50/f0/9c/hort-park.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A Garden is a delight to the eye and a solace for the soul",
+          "text": "I stayed near Stirling Road and Hort Park is just around the corner from Alexandra Hospital and is at one end of the Alexandra Arch Bridge.  This is the third time I came here. The first time I dropped by here when I intend to take the forest walk to Henderson Waves. The second time, I passed by this park while on my way to explore Kent Ridge Park. I did not spend much time here during the last two occasions and it was just touch and go. But this time I stayed longer for about 2 hours. \n\nThe Visitor Centre was closed as today is a public holiday.  Unlike the previous occasions where I witnessed wedding ceremony held at the viewing platform and sumptuous banquet at the Vineyard restaurant, there was no wedding this time. It was quiet and missed the opportunity to see the pretty charming faces of the brides. \n\nI walked down to the Canopy restaurant at the ground floor and there was a crowd of patrons having their late breakfast or brunch. The restaurant looks unique with plants hanging down from the ceiling and decorative potted plants studded around the corners.  I would come to patronise this restaurant one day with my family and to see if their culinary art is good. There was a shop selling plants and gardening accessories in front of the restaurant and if you want to learn on how to build your own pot, you can consult them daily from 10 am to 7 pm daily. I understand that it is free. \n\nI walked further down to the Balinese Garden; the Edible Garden, the Therapeutic Garden, the Allotment Garden, the Butterfly Garden, the Medicine Garden, the Orchid Garden, the Nature playground, etc. I particularly like the Edible Garden and the Allotment Garden as they give me ideas on the type of the vegetables that I can grow at my balcony.  I went around to browse at all the edible plants I know and I saw ladyfinger plants, the mini brinjal, papaya, sweet potato leaves. aloe vera. The strong fragrance of Pandan leaves pervaded the atmosphere as I rooamed at the Edible Garden.  \n\nI spoke to someone at the Allotment Garden who was seen cutting the sweet potato leaves that she harvested and she commented that diligence is imperative in caring for the plants otherwise it would overgrown or eaten by worms. \n\nI love the different colourful species of orchid plants in the Orchid Garden but lamented not knowing much of the plants in the Medicine Garden. It would be ideal if Nparks can assign someone to station at the respective gardens to explain on the type of plants and how to grow them or provide complimentary seeds to those who are interested. \n\nThis Hort Park is very suitable for family outing especially for those with young kids. There are few playgrounds for children to enjoy. And this time, I saw a number of families brought their kids here to enjoy nature. The Nature Playground which is meant for kids fascinated me.  It is good to inculcate in the young the love for nature. As I walk around the nature playground, the bee-hive box, the sound of the cicada and the whistling birds flooded my ears. The butterflies fluttering past me and suddenly a squirrel would dash out from no where up the tree. It would be real fun for kids to experience what is nature when most are brought up in the concrete jungle. \n\nA Garden is a delight to the eye and a solace for the soul. I am not a Zen master but after walking here for an hour plus, I felt relieved and my mind turned out to be more  calmer and less tense. \n\n"
+        },
+        {
+          "title": "A learning park",
+          "text": "Again, I enjoyed my repeat visit to Hort Park as there are always new plants to discover and learn about.  On the slope going down to the garden from the lobby, I was happy to see to uncommon creepers, the Silky Afgekia and the Elephant Creeper.  I also enjoyed learning that Globe Amaranth is an edible plant grown in the Edible Garden together with the orange Cosmos flowers.\nAnother interesting feature is the various trees with roads named after them.  All these informations are well explained on the sign board next to the trees.  I learned that there are Kasai Road and Saraca Road in Singapore.  In fact the nearby roads there are all named after plants and trees.  Athough the orchid enclosure is a small area, we were pleasantly surprised to find the name of an orchid which we having been searching for.  Children are well entertained here with the playground and the native garden."
+        },
+        {
+          "title": "Relaxing park with diversified nature",
+          "text": "Visited Hort Park yesterday. \n\nBeautiful gardens once you find the entrance. The gardens do not offer much shade but there are areas you can sit out of the direct sun if you walk. \n\nGreat flora: figs, bananas, cotton, gingers etc. Lots of birds including collared kingfisher, mynahs, doves and bee catchers. Relax by the reservoir / pond. Nice to rest a while. Note exiting the park by the rear involves a steep walk - you have been warned. Nice, well laid out gardens with drinks vending machines and snacks in the centre area. Also a few restaurants but I didn’t explore. "
+        },
+        {
+          "title": "Not to be missed",
+          "text": "Singapore has many gardens but this has got to be an essential on your Singapore bucket list.  Divided into \"bite sized\" themed chunks it is an absolute joy to wander through.  The children's exploration and play garden is a particular joy.  Walking on to the tree top walk gave a further dimension to the visit."
+        },
+        {
+          "title": "Park with many different Gardens",
+          "text": "Spent a lovely Saturday noon here with the family. Our first visit to the Park and we enjoyed tremendously.\n\n Numerous small little gardens and playground scattered within. Sand pits too ! Easy to walk. Not many people when we were there. \n\nMy children got to see Cotton trees, Banana trees, cute Papaya trees, lemon tree and different types of vegetables and even brinjal.\n\nDefinitely an educational trip not only for them but us too! Highly recommended for families with young children."
+        }
+      ],
+      "description": "Learning and education are two of Hort Park’s main aims, and activities and events are held all year round to generate interest and enhance awareness of the area.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2344355-Reviews-Hort_Park-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "33 Hyderabad Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "119578",
+        "address_string": "33 Hyderabad Road, Singapore 119578 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.279139",
+      "longitude": "103.79981",
+      "timezone": "Asia/Singapore",
+      "website": "https://beta.nparks.gov.sg/visit/parks/park-detail/hortpark",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2344355-Hort_Park-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#99 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "99"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "140",
+      "review_rating_count": {
+        "1": "1",
+        "2": "0",
+        "3": "16",
+        "4": "59",
+        "5": "64"
+      },
+      "photo_count": "451",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2344355-m66827-Reviews-Hort_Park-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Parks",
+              "localized_name": "Parks"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622623",
+          "name": "Kent Ridge"
+        },
+        {
+          "location_id": "15622357",
+          "name": "Queenstown"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "2"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "27"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "25"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "32"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "30"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "33 Hyderabad Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "119578",
+        "address_string": "33 Hyderabad Road, Singapore 119578 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Adventure Cove Waterparkâ„¢ Singapore": [
+    {
+      "location_id": "3747640",
+      "name": "Adventure Cove Waterpark",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/d5/34/b7/adventure-cove-waterpark.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0b/a0/b9/cb/riptide-rocket.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0b/a0/c2/14/big-bucket-treehouse.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0b/a0/b9/ce/tidal-twister.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0b/a0/b9/cd/pipeline-plunge.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Fun rides!",
+          "text": "Really nice and different rides to the whole family to enjoy! I went on a sunday morning and it was a little bit crowded but didn’t stop us from having fun!"
+        },
+        {
+          "title": "One-of-a kind water park",
+          "text": "We had a great time at Adventure Cove Water park. It was a unique experience since we can enjoy the park while having marine encounters with sealife. It was amazing! The food was also good for sharing so overall it was good. Kids get a free souvenir along with the kids meal. Overall it was worth the money you paid for."
+        },
+        {
+          "title": "Well designed and family friendly",
+          "text": "The water park is beautiful designed and has a lot of fun things: a lazy river that goes through a cave, dolphins and snorkeling with the fish. They had to close for thunder so we didn't get to do it all. There are lockers, a drying booth (both for a fee) and nice food options."
+        },
+        {
+          "title": "Cold water",
+          "text": "Adventure Cove, as clean as it is, it is quite old and run down.  Mostly, the water was just too cold even considering the humid Singapore weather. We tried but couldn’t enjoy ourselves with how cool the water was."
+        },
+        {
+          "title": "Amazing",
+          "text": "Amazing exeperience. The food is so gooooooooodd. Would love to come back again. The food quite expensive but the taste was good"
+        }
+      ],
+      "description": "Thrilling slides and encounters with marine life - all in one place. At Adventure Cove Waterpark, you can take high-speed water slides, laze the day away drifting on a lazy river, snorkel with 20,000 tropical fish over a colourful reef, wade among rays and even come face to face with sharks! Come have fun today! Where the water's full of life.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294264-d3747640-Reviews-Adventure_Cove_Waterpark-Sentosa_Island.html?m=66827",
+      "address_obj": {
+        "street1": "8 Sentosa Gateway",
+        "street2": "Resort World Sentosa",
+        "city": "Sentosa Island",
+        "state": "Sentosa Island",
+        "country": "Singapore",
+        "postalcode": "098269",
+        "address_string": "8 Sentosa Gateway Resort World Sentosa, Sentosa Island 098269 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "Island",
+          "name": "Sentosa Island",
+          "location_id": "294264"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.257712",
+      "longitude": "103.81794",
+      "timezone": "Asia/Singapore",
+      "email": "attractions@rwsentosa.com",
+      "website": "http://www.rwsentosa.com/en/attractions/adventure-cove-waterpark?utm_source=tripadvisor_acw&utm_medium=affiliates&utm_campaign=businesslistings",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294264-d3747640-Adventure_Cove_Waterpark-Sentosa_Island.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294264",
+        "ranking_string": "#2 of 29 things to do in Sentosa Island",
+        "geo_location_name": "Sentosa Island",
+        "ranking_out_of": "29",
+        "ranking": "2"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "2765",
+      "review_rating_count": {
+        "1": "121",
+        "2": "142",
+        "3": "411",
+        "4": "962",
+        "5": "1129"
+      },
+      "photo_count": "990",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294264-d3747640-m66827-Reviews-Adventure_Cove_Waterpark-Sentosa_Island.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1700"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 17:00",
+          "Tuesday: 10:00 - 17:00",
+          "Wednesday: 10:00 - 17:00",
+          "Thursday: 10:00 - 17:00",
+          "Friday: 10:00 - 17:00",
+          "Saturday: 10:00 - 17:00",
+          "Sunday: 10:00 - 17:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "amusement_parks",
+          "localized_name": "Water & Amusement Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Water & Amusement Parks",
+          "localized_name": "Water & Amusement Parks",
+          "categories": [
+            {
+              "name": "Water Parks",
+              "localized_name": "Water Parks"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "7"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "354"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "40"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "1741"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "285"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "8 Sentosa Gateway",
+        "street2": "Resort World Sentosa",
+        "city": "Sentosa Island",
+        "state": "Sentosa Island",
+        "country": "Singapore",
+        "postalcode": "098269",
+        "address_string": "8 Sentosa Gateway Resort World Sentosa, Sentosa Island 098269 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Singapore River: History & Culture Tours": [
+    {
+      "location_id": "6692280",
+      "name": "Singapore River Cruise",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/ab/b6/99/bumboat-river-tour.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0f/27/01/04/boat-quay.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/35/59/32/bumboat-river-tour.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0f/27/01/5c/cruising-by-merlion-park.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0f/27/01/59/marina-bay.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Thoroughly Enjoyable!",
+          "text": "I adored this river cruise. Our family of five had the boat to ourselves except for another couple. We sat up the back (which is uncovered) and had a thoroughly enjoyable time.\n\nWe left at nightfall (dusk) and by halfway through the cruise, it was dark, and Singapore's lights revealed themselves in all their beautiful glory!\n\nThe recorded guide over the speaker was informative and not too loud or intrusive, and we all found it be very interesting and relaxing.\n\nThe 'bumboat' cruise on the river was one of the most pleasant and enjoyable moments of our 6 day stay in Singapore. Highly recommended!"
+        },
+        {
+          "title": "NOT RECOMMENDED...",
+          "text": "Its a rip off cruise, not worth it at all. It says 40 min but they cut the tour short and we were back in 25 min. Not recommended at all."
+        },
+        {
+          "title": "Gorgeous look at the city from the water",
+          "text": "I highly recommend taking the river cruise on your first day here as it gives you a great introduction and look at Singapore. The dock and the ticket office is at the end of Clarke Quay - very easy to find on the mapping apps. The queue moves quickly as there are multiple boats in operation. You do not need to purchase tickets in advance. We arrived in the evening so that we could see the cityscape lit up, and the views were breathtaking. The cruise is roughly 45 minutes around the harbor and is accompanied with a helpful recorded narration."
+        },
+        {
+          "title": "Historic Singapore from the river",
+          "text": "Travelling by bumboat provides an interesting view of some of city.  Many historic places are passed with good information provided by the recorded commentary.  We did the cruise on a rainy day and it was a good way to see the sights without getting wet.  Highly recommended."
+        },
+        {
+          "title": "Worth doing.",
+          "text": "I found this very enjoyable. Its a short cruise about 40 mins but well worth it as it gives a really good view of the clarke quay and merlion park area and the view of the buildings from the water is really good. Smooth journey and even though it rained a bit  all good as there is a covered par of the ship. The clarke quay embarkation point is very near some restaurants also. Good tips and some funny banter from the guide."
+        }
+      ],
+      "description": "Cruising since 1987. For more than a decade and a half, bumboats have been plying the Singapore River. The story of Singapore River Cruise begins in 1987. The \"Clean Rivers Campaign\" of 1983 saw the relocation of bumboats to Pasir Panjang. The familiar painted faces of our Bumboats were due to disappear from its home, until SRC was awarded the tender license to run river services here - the first also, to operate such services along the river. We are entering a new chapter in the Singapore River story. In this modern age, Bumboats on this historic waterway remind us of its rustic charm. SRC has been preserving the heritage of this important river for more than two decades. Its bumboats have become the icon of our river to visitors and locals alike. 2008 was a year when our iconic bumboats underwent a transformation. The diesel-powered engines of SRC's fleet made way for a new generation of electric ones that boast quieter engines and zero CO2 emissions. These are the very boats that operate along the Singapore River today. SRC is committed to greater excellence. Under its strong management, the company has developed a firm network of channel intermediaries from government agencies, embassies, event organizers and other operators in the tourism sector, both local and overseas. From a humble fleet of 4 bumboats in 1987, SRC has since increased its number to 24 today with a few new additions coming onboard soon.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d6692280-Reviews-Singapore_River_Cruise-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "3 River Valley Road Clarke Quay",
+        "street2": "BayFront South",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179019",
+        "address_string": "3 River Valley Road Clarke Quay BayFront South, Singapore 179019 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.29073",
+      "longitude": "103.84591",
+      "timezone": "Asia/Singapore",
+      "email": "tangmond@live.com",
+      "phone": "+65 6336 6111",
+      "website": "http://www.rivercruise.com.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d6692280-Singapore_River_Cruise-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#8 of 129 Boat Tours &amp; Water Sports in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "129",
+        "ranking": "8"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "2593",
+      "review_rating_count": {
+        "1": "81",
+        "2": "59",
+        "3": "275",
+        "4": "1019",
+        "5": "1159"
+      },
+      "photo_count": "2490",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d6692280-m66827-Reviews-Singapore_River_Cruise-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "boat_tours_water_sports",
+          "localized_name": "Boat Tours & Water Sports"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "outdoor_activities",
+          "localized_name": "Outdoor Activities"
+        },
+        {
+          "name": "transportation",
+          "localized_name": "Transportation"
+        },
+        {
+          "name": "sightseeing_tours",
+          "localized_name": "Tours"
+        },
+        {
+          "name": "activities",
+          "localized_name": "Activities"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Tours",
+          "localized_name": "Tours",
+          "categories": [
+            {
+              "name": "Boat Tours",
+              "localized_name": "Boat Tours"
+            },
+            {
+              "name": "Historical & Heritage Tours",
+              "localized_name": "Historical & Heritage Tours"
+            }
+          ]
+        },
+        {
+          "name": "Boat Tours & Water Sports",
+          "localized_name": "Boat Tours & Water Sports",
+          "categories": [
+            {
+              "name": "Boat Tours",
+              "localized_name": "Boat Tours"
+            }
+          ]
+        },
+        {
+          "name": "Transportation",
+          "localized_name": "Transportation",
+          "categories": [
+            {
+              "name": "Ferries",
+              "localized_name": "Ferries"
+            }
+          ]
+        },
+        {
+          "name": "Outdoor Activities",
+          "localized_name": "Outdoor Activities",
+          "categories": [
+            {
+              "name": "Boat Tours",
+              "localized_name": "Boat Tours"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291610",
+          "name": "The Quays"
+        },
+        {
+          "location_id": "15622523",
+          "name": "Clarke Quay"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "66"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "981"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "191"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "565"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "359"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "3 River Valley Road Clarke Quay",
+        "street2": "BayFront South",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "179019",
+        "address_string": "3 River Valley Road Clarke Quay BayFront South, Singapore 179019 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Joo Chiat/Katong: Singapore Peranakan Neighbourhood": [
+    {
+      "location_id": "2344138",
+      "name": "Katong-Joo Chiat",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/26/75/ae/c0/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/3a/33/fa/por-las-calles-de-katong.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/ee/a6/b3/20170404-162559-largejpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/18/3b/6d/8c/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/03/96/63/f6/katong-district.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Discovering the Charm of Katong: A Blend of Heritage and Modern Comforts",
+          "text": "Katong is my favorite place in Singapore, with its charming classical houses and colors that are quintessentially Singaporean. Since the new Marine Parade MRT station opened in 2024, access from the city center has become much easier. Cafe hopping and enjoying Laksa are also great activities to try when visiting this area."
+        },
+        {
+          "title": "Great area for a slow wander,",
+          "text": "Excellent historic area not taken over by high rise blocks. Beautifully coloured authentic houses and the best of food to be had. Peranankan food. Cafes and small eateries make it a pleasant area to wander and have regular breaks."
+        },
+        {
+          "title": "Exploring",
+          "text": "Fabulous  to explore and experience.\nGreat little markets  restaurants, bakeries and bars\nClose to shopping centres\nReally unique part of Singapore "
+        },
+        {
+          "title": "Up and coming neighbourhood",
+          "text": "For many years, we had stayed in the centre of the city and most often in Clarke Quay. . Whilst this definitely has its appeal we won’t be staying there anymore as we’ve discovered a new and interesting area.\n\nThe hotel was bang in the middle of it and we loved it. public transport isn’t the best we getting into the centre but taxis and buses are frequent and I believe they are building an MRT station nearby. The bars, restaurants and shops are unique and have their own charm in amongst historic buildings, this really is an interesting place and we are looking forward to getting back as soon as possible."
+        },
+        {
+          "title": "The coolest place in Singapore",
+          "text": "Yesterday I travelled to Katong synonymous with Peranakan cuisine, particularly a spicy Straits Chinese noodle soup called Katong Laksa. The dish has become infamous in the region and walls inside the famous retreat are adorned with articles from publications also Katong has over the years been known for its blend of colourful shophouses, diverse dining options, and cool indie retail stores. \n\nI have to say Katong is most certainly one of the coolest neighbourhoods I have visited since being here and one which I will certainly explore further."
+        }
+      ],
+      "description": "Immerse yourself in Peranakan culture on your visit to Katong and Joo Chiat, and also enjoy its wealth of good food and cultural heritage.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2344138-Reviews-Katong_Joo_Chiat-Singapore.html?m=66827",
+      "address_obj": {
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "427585",
+        "address_string": "Singapore 427585 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.310199",
+      "longitude": "103.90249",
+      "timezone": "Asia/Singapore",
+      "website": "http://www.yoursingapore.com/content/traveller/en/browse/see-and-do/culture-and-heritage/cultural-precincts/joo-chiat-katong.html?TAHotelCode=127",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2344138-Katong_Joo_Chiat-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#70 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "70"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "372",
+      "review_rating_count": {
+        "1": "3",
+        "2": "6",
+        "3": "63",
+        "4": "168",
+        "5": "132"
+      },
+      "photo_count": "759",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2344138-m66827-Reviews-Katong_Joo_Chiat-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "other",
+          "localized_name": "Other"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Neighborhoods",
+              "localized_name": "Neighborhoods"
+            }
+          ]
+        },
+        {
+          "name": "Other",
+          "localized_name": "Other",
+          "categories": [
+            {
+              "name": "Neighborhoods",
+              "localized_name": "Neighborhoods"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622354",
+          "name": "Marine Parade"
+        },
+        {
+          "location_id": "15622462",
+          "name": "Katong"
+        },
+        {
+          "location_id": "7291626",
+          "name": "Joo Chiat"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "5"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "76"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "67"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "80"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "61"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "427585",
+        "address_string": "Singapore 427585 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Sentosa Island, Singapore: Leisure & Attractions": [
+    {
+      "location_id": "2439664",
+      "name": "Universal Studios Singapore",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/e2/fe/30/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0a/3c/87/b6/the-lost-world.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0a/57/dd/bd/meet-diane-jurassic-park.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0a/57/dd/bb/the-cruisers.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0a/57/dd/ba/the-cruisers.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A magic place",
+          "text": "One of my dream bucket list. I’ve been wanting to come here since I was young, but somehow managed to be here when I’m older. This place is magical and always makes me feel young!"
+        },
+        {
+          "title": "Ride the Cylone Rollercoaster,  the wait is worth it.",
+          "text": "When we were there it wasn't that busy.  Although we opted for the Express pass some rides only had a 10 min waiting time.  Get there when it opens to avoid the crowds. It's  smaller than Japan and California,  but still worthwhile.  Best roller-coaster  - Cylone."
+        },
+        {
+          "title": "Great Day Out",
+          "text": "Was exceptionally clean and staff exceptionally hospitable, not large but can do comfortably in a full day.unfortunately several rides closed due to inclement weather"
+        },
+        {
+          "title": "Best family day",
+          "text": "USS is the best theme park to visit, the newly opened minionland was also so much fun. My kids were the most excited ones!!"
+        },
+        {
+          "title": "Good",
+          "text": "The place is full of great entertainment and fun, The express ticket as they say allows you to access everything without waiting in a queue but that is not true, the staff member outside informed us that there is two types of express ticket, one with exeption for some games where you have to wait in a ling queue and another express when you pay higher price so you access everything without waiting, then when we got inside that was not correct as in some games we were told that we cant use express ticket, and if you will go to repeat one game that you like then you cannot use the express ticket, it's only one time use,  also we had to pay for the dryer after we got wet with water spalsh game, so what's the use of paying extra for express ticket. Many people from different countries are visiting the place there should be a variety of global fast food restaurant, but there is not, also the drinks should be better and have vriety but all the of them sell the same juice every where there. Also one show at water world i missed it some years ago as the last show was at 3 pm, and last week this side was closed for maintenance which was disappointing. They need to have more seating areas with air condition so people can rest in between as the weather is so hot. The experience was overall good but a lot of dissappointments here and there."
+        }
+      ],
+      "description": "Singapore’s only movie-theme park features 24 rides and attractions, including a pair of dueling coasters that brush past one another in several near misses in their aerial combat. Thrill-seekers can choose between a coaster where they are seated or the other where riders are suspended. Exciting loops, sudden turns, breathtaking drops and thrilling near-collisions will make you scream your heart out. Dinosaurs, lemurs, ogres and Egyptian mummies add to the thrills and adventures.With 18 attractions created or redesigned for Singapore, Universal Studios Singapore™ promises an experience that you will not forget. Laughter and screams are heard around every corner, and lasting memories are made every day. Themed dining and shops are available. UNIVERSAL STUDIOS, UNIVERSAL STUDIOS SINGAPORE, Universal Globe logo, and all Universal elements and related indicia ™ & © Universal Studios. All Rights Reserved.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294264-d2439664-Reviews-Universal_Studios_Singapore-Sentosa_Island.html?m=66827",
+      "address_obj": {
+        "street1": "8 Sentosa Gateway",
+        "street2": "Resorts World Sentosa",
+        "city": "Sentosa Island",
+        "state": "Sentosa Island",
+        "country": "Singapore",
+        "postalcode": "098269",
+        "address_string": "8 Sentosa Gateway Resorts World Sentosa, Sentosa Island 098269 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "Island",
+          "name": "Sentosa Island",
+          "location_id": "294264"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.254",
+      "longitude": "103.824",
+      "timezone": "Asia/Singapore",
+      "email": "enquiries@rwsentosa.com",
+      "phone": "+65 6577 8888",
+      "website": "http://www.rwsentosa.com/en/attractions/universal-studios-singapore?utm_source=tripadvisor_uss&utm_medium=affiliates&utm_campaign=businesslistings",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294264-d2439664-Universal_Studios_Singapore-Sentosa_Island.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294264",
+        "ranking_string": "#1 of 29 things to do in Sentosa Island",
+        "geo_location_name": "Sentosa Island",
+        "ranking_out_of": "29",
+        "ranking": "1"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "20625",
+      "review_rating_count": {
+        "1": "628",
+        "2": "623",
+        "3": "2307",
+        "4": "6655",
+        "5": "10412"
+      },
+      "photo_count": "22557",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294264-d2439664-m66827-Reviews-Universal_Studios_Singapore-Sentosa_Island.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 19:00",
+          "Tuesday: 10:00 - 19:00",
+          "Wednesday: 10:00 - 19:00",
+          "Thursday: 10:00 - 19:00",
+          "Friday: 10:00 - 19:00",
+          "Saturday: 10:00 - 19:00",
+          "Sunday: 10:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "amusement_parks",
+          "localized_name": "Water & Amusement Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Water & Amusement Parks",
+          "localized_name": "Water & Amusement Parks",
+          "categories": [
+            {
+              "name": "Theme Parks",
+              "localized_name": "Theme Parks"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "186"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "4269"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "645"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "8942"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "3137"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "AmusementWaterParks"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        }
+      ],
+      "address": {
+        "street1": "8 Sentosa Gateway",
+        "street2": "Resorts World Sentosa",
+        "city": "Sentosa Island",
+        "state": "Sentosa Island",
+        "country": "Singapore",
+        "postalcode": "098269",
+        "address_string": "8 Sentosa Gateway Resorts World Sentosa, Sentosa Island 098269 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Chinatown Singapore: History & Culture": [
+    {
+      "location_id": "317415",
+      "name": "Chinatown",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/1b/73/65/d0/photo9jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/00/18/cc/98/streets-of-chinatown.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/24/c5/ce/1f/per-le-vie-di-chinatown.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/24/c5/cd/f7/per-le-vie-di-chinatown.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/24/c5/cd/d6/per-le-vie-di-chinatown.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Chinatown ",
+          "text": "It is easy to get to using the MRT and a good place to have a wander around for an hour or two. There are plenty of souvenir shops at reasonable prices. Loads of restaurants and bars to choose from. Some great temples for those photo opportunities."
+        },
+        {
+          "title": "Typical Chinatown",
+          "text": "Some of the old historic buildings were nice. But, all the stalls selling souvenirs were similar. It’s a typical Chinatown with some street foods and cheap trinkets. The Buddha Tooth Relic Temple is the highlight here!"
+        },
+        {
+          "title": "Chinatown for heritage & shopping bargains",
+          "text": "We had visited the large Buddhist temple when we realised on leaving the temple we were literally around the corner from Chinatown and all the shopping stalls and colourful heritage buildings. \n\nThe markets can be and were super crowded with a huge variety of items for sale. This is the cheapest place in all of Singapore for souveniers. I wish we had known about it at the start of our holiday rather than the end of it. This still did not stop us from buying up lots of little presents. \n\nWe even found a place to sit down and have some lunch. A visit to Chinatown should be a must and it is well worth the crowds to get those bargains."
+        },
+        {
+          "title": "A do not miss spot to experience Singapore ",
+          "text": "Fantastic spot to be in Singapore, still has the old heart of Singapore ticking, authentic shopping and amazing dining options, great area that you felt safe in, and could enjoy wandering around in for hours, we visited close to Chinese New Year, so had that extra decorated excitement you would expect "
+        },
+        {
+          "title": "Merely a tourist place",
+          "text": "It might have had some charme years ago but today it is merely a tourist place with lot of shops selling a lot souvenirs but honestly nothing interesting in it"
+        }
+      ],
+      "description": "For a fascinating peek into Singapore’s Chinese culture and history, Chinatown is good place to start. Here, you’ll enjoy a mix of heritage visits to museums, shopping as well as a good variety of food options, sure to leave a traveller happy and satisfied at the end of the day.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d317415-Reviews-Chinatown-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Crot",
+        "street2": "Trengganu",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "048942",
+        "address_string": "Crot Trengganu, Singapore 048942 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.281539",
+      "longitude": "103.84472",
+      "timezone": "Asia/Singapore",
+      "website": "http://www.chinatown.sg/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d317415-Chinatown-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#12 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "12"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "14606",
+      "review_rating_count": {
+        "1": "122",
+        "2": "311",
+        "3": "2295",
+        "4": "6255",
+        "5": "5623"
+      },
+      "photo_count": "11454",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d317415-m66827-Reviews-Chinatown-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0800"
+            },
+            "close": {
+              "day": 1,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0800"
+            },
+            "close": {
+              "day": 2,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0800"
+            },
+            "close": {
+              "day": 3,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0800"
+            },
+            "close": {
+              "day": 4,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0800"
+            },
+            "close": {
+              "day": 5,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0800"
+            },
+            "close": {
+              "day": 6,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0800"
+            },
+            "close": {
+              "day": 7,
+              "time": "0000"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 08:00 - 00:00",
+          "Tuesday: 08:00 - 00:00",
+          "Wednesday: 08:00 - 00:00",
+          "Thursday: 08:00 - 00:00",
+          "Friday: 08:00 - 00:00",
+          "Saturday: 08:00 - 00:00",
+          "Sunday: 08:00 - 00:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "other",
+          "localized_name": "Other"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Neighborhoods",
+              "localized_name": "Neighborhoods"
+            }
+          ]
+        },
+        {
+          "name": "Other",
+          "localized_name": "Other",
+          "categories": [
+            {
+              "name": "Neighborhoods",
+              "localized_name": "Neighborhoods"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622374",
+          "name": "Outram"
+        },
+        {
+          "location_id": "15622676",
+          "name": "Central Business District"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291616",
+          "name": "Chinatown"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "548"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "5064"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "1578"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "2573"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "2264"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "TopAttractions"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        },
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "Crot",
+        "street2": "Trengganu",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "048942",
+        "address_string": "Crot Trengganu, Singapore 048942 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Buddha Tooth Relic Temple & Museum in Singapore": [
+    {
+      "location_id": "1438273",
+      "name": "Buddha Tooth Relic Temple and Museum",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0b/ce/1f/25/photo2jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-o/03/cd/dc/ac/buddha-tooth-relic-temple.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/3f/3b/ad/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/3f/3b/b2/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/3f/3b/b7/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Free to visit, full of history",
+          "text": "Built in 2007 at a cost of $75,000,000 Singapore dollars this Tang-styled Temple resides prominently in Chinatown.  Home to thousands of statues, two museums and a lot of scripture believers will be drawn to the enormous gold vessel reportedly home to Buddha's left canine tooth.  Free to visit."
+        },
+        {
+          "title": "Not enough time in Temple",
+          "text": "The Buddha Tooth Relic temple & museum is in china town, this stunning temple hall with over 1000 Buddha on the first floor is amazing.\nThe interior on the ground floor was large & lovely, red & gold everywhere. Built in the 2000’s it has a lift to the fifth floor, where is the tooth relic is but unfortunately no photos can be taken & you must remove your shoes. The museum & the rest of the building you leave your shoes on. I wore shorts just about the knees & had no trouble entering the temple.\nThis is another must do while in Singapore."
+        },
+        {
+          "title": "Amazing!",
+          "text": "One of the coolest things I've ever seen while travelling! They provide cover ups if you're wearing shorts or tank tops. The temple was absolutely stunning. Make sure you visit all the floors! The sanctuary on the roof was beautiful and so peaceful!"
+        },
+        {
+          "title": "Lovely Temple",
+          "text": "This is a beautiful temple with large statues in the front and many smaller ones on the walls. Appropriate attire is required. They have some scarves to hand out if your knees or shoulders are bare. We went up to the 4th floor to see the Buddha Tooth Relic which was behind glass. You have to take off your shoes. Photo taking was not allowed here. They had beads for sale. \n\nThe monks were preparing for a prayer service when we were there. You have to make reservations for a kneeling bench spot to be part of the prayers. As they were closing, we didn’t have time to visit the roof top garden or the museums on the other floors. Yes, it’s worth a visit. The energy was very good here in here."
+        },
+        {
+          "title": "Really beautiful temple",
+          "text": "Inside it’s awesomely opulent, really over the top in style.\nMain features are the hall of 100 Buddhas on level 1, and the repository of Buddha’s tooth on level 5.  We also visited level 4 with lots of relics, but felt that was less interesting to visitors.\nThe disabled will have no problems, there’s step free access, and lifts between floors, although I don’t think you can visit the roof garden without climbing stairs.\nLike many famous places of worship, it’s swamped by visitors, so don’t expect to see many paying their respects to the Buddha. We did see several meditating, but to see Buddhism at its best, you’ll need to visit another temple.\nOverall, this is a splendid place to visit when you’re in Singapore."
+        }
+      ],
+      "description": "The Buddha Tooth Relic Temple and Museum (BTRTM) was founded in 2002 by Venerable Shi Fazhao. It was registered by the Registrar of Societies in 20th February 2003, and as a charity under the Charities Act in 8th January 2004. The Temple is dedicated to the Maitreya Buddha, which means 'The Compassionate One', and also called 'The Future Buddha'. (A)WEEKLY FREE GUIDED TOUR: BTRTM is pleased to offer a 1 1/2 - 2 hrs long guided tour of the Temple every Saturdays at 2pm. The tour will be conducted free-of-charge in English by the temple's Volunteers guides. Limited slots are available per weekly session. Confirmed registration is based on first-come-first-serve basis. (B)DISCOVERING BUDDHISM: Shakyanmuni Buddha had gained insight into the truth, perfected the qualities of wisdom and compassion over 2560 years ago. His teachings develops clarity in minds, enables abilities to end suffering and finds lasting happiness. Buddha Tooth Relic Temple is carrying on the mission in offering \"Discovering Buddhism' programme. 'Discovering Buddhism' is a specially designed programme for participants to gain experiential taste of Chinese Mahayana Buddhist etiquette, Basic Buddhist teachings and Basic Meditation within a day. This English taught programme is suitable for both tourists who wish to learn more about Buddhism and experienced learners who needs a refresher. Participants will benefit from the interactive and engaging teaching led by Venerable Wu Xiang and Venerable Ru Zhi who have more than a decade experience teaching Buddhism and Meditation in different cultural settings! [Chinese Mahayana Buddhist Etiquette] Buddhist etiquette is an important part of every Buddhist life. It expresses religious sentiments to the Buddha, the Teacher (Monk or Nun) and promotes gracefulness in social interactions. This is also a mean of training in mindfulness in every action one is taking. [Basic Buddhist teachings] Buddhism has been transmitted over the past centuries because of its timeless and enduring message to the spiritual needs of man in finding true peace, happiness, and well-being. In this part of the programme, learn about the basic essential knowledge of Buddhism. [Basic Meditation] Buddhist have been practicing meditation in cultivating calm, focused and positive states of mind. Introductory of technique will be taught to enable the participants to learn practical tips on how to achieve a clearer state of mind and focus better. Things to take note : * Avoid wearing hats, shorts or revealing tops * The organizer reserves the right to cancel the tour due to unforeseen circumstances. In such instances, registrants will be notified via their mobile phones.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d1438273-Reviews-Buddha_Tooth_Relic_Temple_and_Museum-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "288 South Bridge Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "058840",
+        "address_string": "288 South Bridge Road, Singapore 058840 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.281531",
+      "longitude": "103.84424",
+      "timezone": "Asia/Singapore",
+      "email": "services@btrts.org.sg",
+      "phone": "+65 6220 0220",
+      "website": "http://www.btrts.org.sg/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d1438273-Buddha_Tooth_Relic_Temple_and_Museum-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#22 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "22"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "6540",
+      "review_rating_count": {
+        "1": "16",
+        "2": "48",
+        "3": "526",
+        "4": "2339",
+        "5": "3611"
+      },
+      "photo_count": "6802",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d1438273-m66827-Reviews-Buddha_Tooth_Relic_Temple_and_Museum-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0700"
+            },
+            "close": {
+              "day": 1,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0700"
+            },
+            "close": {
+              "day": 2,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0700"
+            },
+            "close": {
+              "day": 3,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0700"
+            },
+            "close": {
+              "day": 4,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0700"
+            },
+            "close": {
+              "day": 5,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0700"
+            },
+            "close": {
+              "day": 6,
+              "time": "1700"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0700"
+            },
+            "close": {
+              "day": 7,
+              "time": "1700"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 07:00 - 17:00",
+          "Tuesday: 07:00 - 17:00",
+          "Wednesday: 07:00 - 17:00",
+          "Thursday: 07:00 - 17:00",
+          "Friday: 07:00 - 17:00",
+          "Saturday: 07:00 - 17:00",
+          "Sunday: 07:00 - 17:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Sacred & Religious Sites",
+              "localized_name": "Sacred & Religious Sites"
+            }
+          ]
+        },
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Specialty Museums",
+              "localized_name": "Specialty Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622374",
+          "name": "Outram"
+        },
+        {
+          "location_id": "15622676",
+          "name": "Central Business District"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291616",
+          "name": "Chinatown"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "235"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "2191"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "915"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "1296"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "1087"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "TopAttractions"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        },
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "288 South Bridge Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "058840",
+        "address_string": "288 South Bridge Road, Singapore 058840 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Labrador Nature Reserve": [
+    {
+      "location_id": "2344142",
+      "name": "Labrador Nature Reserve",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/b7/c2/df/photo4jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/06/3d/b0/photo4jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/b0/40/17/filename-05-jpg-thumbnail0.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/81/35/fc/welcome-to-labrador-park.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/49/44/e0/labrador-nature-reserve.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Pleasant walk",
+          "text": "We caught the train to the Labrador MRT, then walked through the Labrador Nature Reserve, along the Bukit Chermin Boardwalk, past the Reflections complex, and on to the Harbour Front Centre. A very pleasant walk."
+        },
+        {
+          "title": "A wonderfully peaceful escape from the city - local wildlife and beautiful coastal path views",
+          "text": "I had a spare few hours on a recent cruise ship visit to Singapore and saw this place on the map, read a few reviews and decided to walk here and check it out - I was really pleased I did as it turned out to be a very peaceful and pretty walk amongst local nature with very few people around.\n\nI walked here from Harbourfront along the Telok Blangah road to the Labrador Park MRT station and then took the Berlayer Creek Boardwalk route through to the waterfront. It was so peaceful with just the noise of the cicadas and birds and I also had a close encounter with a monitor lizard who sat on the boardwalk on my journey into the park. At the waterfront I headed first along the new Bukit Chermin Boardwalk towards Keppel Bay and the impressive Reflections condominions. After a short walk in that direction I headed back and then walked into Labrador Park, to the Dragons Teeth Gate and the Berlayer Beacon. I walked the path towards the playground and the jetty before heading into the hilly and wooden area that hides a number of wartime tributes, passing the Fourth Gun Position, the 1892 Storeroom and checked out the Gunners of Labrador Battery Tribute.\n\nIt was a really lovely way to spend a few hours and although I didn't see too much wildlife (apart from the monitor lizard and plenty of chickens) it was so peaceful and there was just nobody around. A perfect break away from the hustle and bustle of the city itself."
+        },
+        {
+          "title": "Exploring a historical site at the nature reserve",
+          "text": "I wandered my way here to explore the historical military site of Fort Pasir Panjang. It is located on the coastal cliff near to the car park B. I entered the nature reserve via the Berlayer Creek mangrove trail. The environment was peaceful and calm. At the look-out point, I sat down to appreciate the sapphire sea water that came in to nourish the mangrove roots. The heavy buzzing of the cicada sound like little alarm welcoming me to the rustic greenery on both sides of the board walk.\n\nIt was breezy taking the coastal walk to the park and I like to hear the rhematic splashing of the sea water against the rocky bank.  From the jetty, I walked my way to the fort area. As I walked up the slope, I saw the site where the British erected the gunnery and the artillery to prevent a naval attack at the southern harbor. The British constructed the most impregnable fortress to guard against intrusions but during the Second World War, the Japanese attacked Singapore from the northern coast instead of the southern coast. The defense strategy did not work, and Singapore lost to the Japanese within a week of fighting.  \n \nThis part of the nature reserve is rather quiet and covered by dense vegetation. I took about an hour to roam around and walked my way to the top and then back to the park. I took the same way out by taking a return walk along the Berlayer Creek.  \n\nWhile walking home, I pondered: would Singapore has fallen if the Japanese would attack from the south instead of from the north? "
+        },
+        {
+          "title": "Good viewpoints",
+          "text": "This reserve offers lovely views across the strait and has multiple walking trails. There are some historical landmarks on the way including the Dragon Tooth Rock and the Red Beacon. It is a modest walk from the nearest MRT station and you can get there by a couple of routes. One way is along the Berlayer Creek Boardwalk which is a 1km trek through the jungle and following a river. Alas we did not see any wildlife except for squirrels. Another way to access the park will be via a boardwalk from Harbourfront but this was under construction when we visited."
+        },
+        {
+          "title": "Rhythm of the rain",
+          "text": "I had been to this nature reserve on a number of occasions with my residents and friends. However, this was the first time I came alone. It started to drizzle when I reached this nature reserve. The right extreme corner of the waterfront was seen barricaded due to a fallen tree caused probably by the heavy rain on the previous night.  \n\nAs I strolled towards the other corner of the waterfront promenade, the rain started to pour heavily.  All the visitors rushed to seek shelter and the promenade look deserted. The atmosphere suddenly became so quiet and calm.  It was a beautiful sensation engaging in a solitary walk along this promenade. It was a pleasure listening to the rhythm of the rain with the splashing sound  of the strong seawaves hitting against the concrete bank at the background. Occasionally, I could hear the momentary dim horning from the distant vessels berth at the anchorage.  \n\nAs I reached the Dragon's teeth Gate or Batu Berlayer area, I remember that this was once a historical pirate hide-out. The British colonialist Admiral Henry Keppel was determined to eradicate them so as to build a strataegic port here. That was history and the gun post did not fascinate me much as I continued my way along the Bukit Chermin Boardwalk. From the jetty, I could view and admire the iconic and elegant architectural design of Reflections at Keppel Bay condo standing tall from a distance.  \n\nThe boardwalk is unique as one has the opportunity to appreciate the mangrove swamp as the boardwalk cut through the mangrove swamp.  I was surprised to see the gigantically thick roots of some of the mangrove trees on the swamp. Then, at the end of the boardwalk, I returned to the Labrador MRT station where I earlier started by journey. \n\n I had a book `An Amazing Rebirth' by Maria Chan Rhomberg with me during the journey.  Her approach to life's impermanence and life's adversity are `Seeing things as they are' and `Letting Go'. Learn to relax and take long walks, paying attention to the natural beauty around you.  And I learn to listen to the rhythm of the rain and appreciate the beauty of the sea horizon."
+        }
+      ],
+      "description": "Explore the rocky cliff-side vegetation and enjoy the panoramic views of the sea at Labrador Nature Reserve. This park is an oasis of calm and a tranquil getaway from the hustle and bustle of the city.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2344142-Reviews-Labrador_Nature_Reserve-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Labrador Villa Road Tanjong Berlayer Park",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "119187",
+        "address_string": "Labrador Villa Road Tanjong Berlayer Park, Singapore 119187 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.27051",
+      "longitude": "103.80166",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6339 6833",
+      "website": "http://www.nparks.gov.sg/gardens-parks-and-nature/parks-and-nature-reserves/labrador-nature-reserve",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2344142-Labrador_Nature_Reserve-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#86 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "86"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "211",
+      "review_rating_count": {
+        "1": "0",
+        "2": "3",
+        "3": "28",
+        "4": "103",
+        "5": "77"
+      },
+      "photo_count": "538",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2344142-m66827-Reviews-Labrador_Nature_Reserve-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Nature & Wildlife Areas",
+              "localized_name": "Nature & Wildlife Areas"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622331",
+          "name": "Bukit Merah"
+        },
+        {
+          "location_id": "15622611",
+          "name": "Maritime Square"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "46"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "40"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "41"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "44"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "Labrador Villa Road Tanjong Berlayer Park",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "119187",
+        "address_string": "Labrador Villa Road Tanjong Berlayer Park, Singapore 119187 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Marina Bay Singapore: Attractions & Things to do": [
+    {
+      "location_id": "2149128",
+      "name": "Gardens by the Bay",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/05/d9/0e/f0/gardens-by-the-bay.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/be/b0/33/gardens-by-the-bay.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/be/ad/12/gardens-by-the-bay.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/04/01/55/ee/gardens-by-the-bay.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/be/b0/39/gardens-by-the-bay.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Impressive but overly-monetized",
+          "text": "Accessed via the dragonfly bridge from Marina Bay Sands or metro to bayfront Gardens by the Bay is a requisite stop for anyone visiting Singapore, the free portion mostly consisting of greenery and elevated platforms while those who want to pay can visit a variety of greenhouses or take an elevator to suspended vantage points including a cafe.  Best visited after sundown when lights turn on and crowds are diminished."
+        },
+        {
+          "title": "Stunning place",
+          "text": "What a beautiful place. You need many hours to walk through the gardens.\nEverything is well looked after. \nEntry is free but if you want to visit the Flower Dome, cloud Forrest or doing the Skywalk it’s an entry fee, but worth it to pay and to see.\nThe super trees are just stunning by day and more stunning at night when the light show begins. It’s also free but be early , it’s packed. \nShow is 7.45 pm and 8.45 pm. Takes approximately 15 min.\nLots of Statues , eateries and restrooms in the park \nMRT is 15 min walk away"
+        },
+        {
+          "title": "Such kind and informative local guides!",
+          "text": "I have yet to write a review on all the wonderful places I've visited but the actions of one kind local guide has inspired me to do so. My husband and I had just about wrapped up our visit to the wonderful cloud forest but we were still clueless on navigating outside the gardens. It was right as we were leaving when we approached a guide, Hazik, who at first seemed at a rush with his clipboard in hand but stopped all he was doing to assist us. He not only kindly explained the directions we requested but started an insightful conversation and even assisted in planning out a detailed itinerary for our brief stay in Singapur. We would like to extend our gratitude for his kindness and patience in guiding us which ultimately was the highlight of our trip to the gardens!"
+        },
+        {
+          "title": "A Dream Fulfilled!!",
+          "text": "THE destination in Singapore! My time in the city was limited, but I still ended up spending basically one entire day roaming the grounds and exploring the different facilities (e.g. Flower Dome, Supertree Grove, Cloud Forest). Tickets are available at various entry points for any or all areas you’d like to see, which, for me, was everything. The cost is pricey but 1000% worth the investment. Multiple food vendors are on the premises. Nearby GBTB (abbreviated name) are Marina Bay Sands (the hotel/casino/shopping mall) and the waterfront promenade, plus a metro station (Bayfront MRT) is connected to everything so one needn’t walk outdoors too much if hot and humid."
+        },
+        {
+          "title": "Lovely walk around. Restaurants and bathrooms",
+          "text": "You need at least two hours here. Be sure to stop on the sixth floor of the marina Bay Sands, Hotel, and then take the escalator down into the gardens so you can take advantage of the views from up there. It is free to go, but there are two gardens that you could pay to enter if you wish."
+        }
+      ],
+      "description": "An integral part of Singapore's \"City in a Garden\" vision, Gardens by the Bay spans a total of 101 hectares of prime land at the heart of Singapore's new downtown - Marina Bay. Comprising three waterfront gardens - Bay South, Bay East and Bay Central - Gardens by the Bay will be a showcase of horticulture and garden artistry that will bring the world of plants to Singapore and present Singapore to the World.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2149128-Reviews-Gardens_by_the_Bay-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "18 Marina Gardens Drive",
+        "street2": "Supertree Grove",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018953",
+        "address_string": "18 Marina Gardens Drive Supertree Grove, Singapore 018953 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.281566",
+      "longitude": "103.86361",
+      "timezone": "Asia/Singapore",
+      "email": "feedback@gardensbythebay.com.sg",
+      "phone": "+65 6420 6848",
+      "website": "http://www.gardensbythebay.com.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2149128-Gardens_by_the_Bay-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#260 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "260"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "61998",
+      "review_rating_count": {
+        "1": "213",
+        "2": "411",
+        "3": "2565",
+        "4": "13971",
+        "5": "44838"
+      },
+      "photo_count": "65497",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2149128-m66827-Reviews-Gardens_by_the_Bay-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0500"
+            },
+            "close": {
+              "day": 1,
+              "time": "0200"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0500"
+            },
+            "close": {
+              "day": 2,
+              "time": "0200"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0500"
+            },
+            "close": {
+              "day": 3,
+              "time": "0200"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0500"
+            },
+            "close": {
+              "day": 4,
+              "time": "0200"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0500"
+            },
+            "close": {
+              "day": 5,
+              "time": "0200"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0500"
+            },
+            "close": {
+              "day": 6,
+              "time": "0200"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0500"
+            },
+            "close": {
+              "day": 7,
+              "time": "0200"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 05:00 - 02:00",
+          "Tuesday: 05:00 - 02:00",
+          "Wednesday: 05:00 - 02:00",
+          "Thursday: 05:00 - 02:00",
+          "Friday: 05:00 - 02:00",
+          "Saturday: 05:00 - 02:00",
+          "Sunday: 05:00 - 02:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            }
+          ]
+        },
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Gardens",
+              "localized_name": "Gardens"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "13210711",
+          "name": "Marina South"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "2280"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "22168"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "5071"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "16283"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "9630"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "TopAttractions"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        },
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "18 Marina Gardens Drive",
+        "street2": "Supertree Grove",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018953",
+        "address_string": "18 Marina Gardens Drive Supertree Grove, Singapore 018953 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Marina Bay Sands, Singapore": [
+    {
+      "location_id": "1062119",
+      "name": "Marina Bay Sands Casino",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/2d/ed/94/f4/marina-bay-sands.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/2d/0b/1e/casino.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/2d/0b/1d/casino.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/2d/0b/1c/blue-pearl.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/2c/54/79/tong-dim.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "One & Done",
+          "text": "Very difficult to enter, must have your passport if not a local.\nVery smokey, difficult if not near impossible to get a mixed drink and if you do only one refill every 30 min unless u get a double then a refill ever hour. Ridiculous!"
+        },
+        {
+          "title": "Pro Tips for the Casino",
+          "text": "Pro tips for the Casino (for foreigners):\n1. Passport and Singapore Arrival Card required for entry (the line moves quickly and it's easy);\n2. Bring your money to the casino (no ATMs in the casino, ask me how I know :)\n3. If taking the MRT (Singapore's subway - which is amazing BTW), go to the Marina Bay stop and follow the signs for the casino - very easy.\n4. A player's card is required if you're cashing out more than 4000 dollars - so might as well get a player's card as you enter the casino - it's easy - just go to the Sands Player's Club desk.\n5. The table games (we played Texas Hold 'Em and 3 Card Poker) are generally $25 and $50.  The slots were generally 2 cents and above, though we did find penny slots.\n6. There was no tax on our winnings of $5k from a slot machine.\n7.  A beer was $10.  Water and soft drinks are free.  The service is great!\n8.  Non-smoking area on the second floor.\n\nEnjoy your time, we thought it was a great place!"
+        },
+        {
+          "title": "can visit this casino and try your luck",
+          "text": "one of the largest casino in the world..\nit has a huge number of tables and its open 24hs\n\nyou can smoke anywhere inside the casino.."
+        },
+        {
+          "title": "Heaven for casino lovers; feel the wibe and win some dollars:-)",
+          "text": "Marina Bay Sands Casino in Singapore\n\nI visited the Marina Bay Sands (MBS) Casino in Singapore from December 9-10. This standalone casino, part of the MBS resort, is one of the world's most expensive, costing over $7 billion USD to build.\nFirst Impressions The casino is enormous, spanning four floors. The check-in process was stringent but fair, likely due to the high-security measures in place to ensure the safety of all guests. While some reviews have criticized this process, I found it acceptable given the importance of security. Foreign guests and Singapore residents have separate lines for entry.\nCasino Experience The casino boasts approximately 700 table games and over 1,400 slot machines. The starting bets for table games were higher than what I am accustomed to in Europe. I tried my luck on the slot machine \"All Aboard\" with a low bet and was fortunate to leave the casino with a win on both days. It's no secret that the odds are against you in the long run, so I quit early to secure my profits. Regardless of winning or losing, it was a pleasant experience and a highlight of my holiday.\n\nPositives\n•\tLarge casino with hundreds of tables and thousands of slot machines.\n•\tGood atmosphere with plenty of options for gaming.\n•\tEasy to spend several hours here.\n•\tGood membership and rewards program.\n\nNegatives\n•\tSmoking in public places is allowed, which I hope will be banned in the future.\n•\tUnlike in Europe, food and drinks are not complimentary.\n•\tThe winning rate is reportedly low, making it challenging to beat the slots and table games.\n\nOverall, the Marina Bay Sands Casino offers a unique and enjoyable experience, despite a few drawbacks."
+        },
+        {
+          "title": "Smoking Allowed…",
+          "text": "Being allowed to smoke in the casino ruined it for me. Would not recommend and found it hard to find tables to play on but could not concentrate with the smell…"
+        }
+      ],
+      "description": "With four levels of gaming floor-space and up to 3,000 electronic gaming machines to choose from, the Casino at Marina Bay Sands offers a vast selection of the newest and most popular electronic gaming machines worldwide with more than 200 game titles to choose from.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d1062119-Reviews-Marina_Bay_Sands_Casino-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "10 Bayfront Avenue",
+        "street2": "Marina Bay Sands Singapore",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018956",
+        "address_string": "10 Bayfront Avenue Marina Bay Sands Singapore, Singapore 018956 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.283588",
+      "longitude": "103.85962",
+      "timezone": "Asia/Singapore",
+      "email": "inquiries@marinabaysands.com",
+      "phone": "+65 6688 8868",
+      "website": "https://www.marinabaysands.com/casino.html",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d1062119-Marina_Bay_Sands_Casino-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#140 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "140"
+      },
+      "rating": "3.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.5-66827-5.svg",
+      "num_reviews": "1341",
+      "review_rating_count": {
+        "1": "123",
+        "2": "93",
+        "3": "279",
+        "4": "436",
+        "5": "410"
+      },
+      "photo_count": "460",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d1062119-m66827-Reviews-Marina_Bay_Sands_Casino-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0000"
+            },
+            "close": {
+              "day": 1,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0000"
+            },
+            "close": {
+              "day": 2,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0000"
+            },
+            "close": {
+              "day": 3,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0000"
+            },
+            "close": {
+              "day": 4,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0000"
+            },
+            "close": {
+              "day": 5,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0000"
+            },
+            "close": {
+              "day": 6,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0000"
+            },
+            "close": {
+              "day": 7,
+              "time": "2359"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 00:00 - 23:59",
+          "Tuesday: 00:00 - 23:59",
+          "Wednesday: 00:00 - 23:59",
+          "Thursday: 00:00 - 23:59",
+          "Friday: 00:00 - 23:59",
+          "Saturday: 00:00 - 23:59",
+          "Sunday: 00:00 - 23:59"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "fun_games",
+          "localized_name": "Fun & Games"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "casinos_gaming",
+          "localized_name": "Casinos & Gambling"
+        },
+        {
+          "name": "activities",
+          "localized_name": "Activities"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Casinos & Gambling",
+          "localized_name": "Casinos & Gambling",
+          "categories": [
+            {
+              "name": "Casinos",
+              "localized_name": "Casinos"
+            }
+          ]
+        },
+        {
+          "name": "Fun & Games",
+          "localized_name": "Fun & Games",
+          "categories": [
+            {
+              "name": "Casinos",
+              "localized_name": "Casinos"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622528",
+          "name": "Bayfront"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "58"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "325"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "204"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "108"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "291"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "10 Bayfront Avenue",
+        "street2": "Marina Bay Sands Singapore",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018956",
+        "address_string": "10 Bayfront Avenue Marina Bay Sands Singapore, Singapore 018956 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Chek Jawa": [
+    {
+      "location_id": "2344353",
+      "name": "Chek Jawa",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0b/9d/ba/72/beautiful-landscape.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/9d/af/71/chek-jawa-village-from.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1a/70/e8/37/photo0jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/15/2b/39/57/sea-grass-lagoon-pontoon.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/10/8c/58/b3/photo8jpg.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Pilau Ubin is Worth a Visit",
+          "text": "A trip out to Pulau Ubin offers a welcome change of pace from built-up Singapore. A 30 minute Grab from Downtown takes you to Changi Ferry terminal from where boats leave regularly, as long as at least 10 people are waiting. Fare is S$4 each way, cash only. In fact almost everything on the island is cash and there are no ATMs, so come prepared. On arrival up the jetty and turn left for the bike hire places. We went to No 45 and got three fairly ancient BMX style bikes for $30 in total. Some bikes have baskets, but no suggestion of helmets, padlock, etc. We then cycled east, along the nice sensory trail to the entrance to the Wetlands. About 3-4 km. It’s well shaded, well way marked and with a few short slight inclines. I’d have thought anyone with modest fitness will find it easy, but don’t forget to bring water. The Wetlands entrance has an obligatory parking place for bikes, toilets, drink vending machine and some info. Two flat trails take you past mangroves then over the sea on raised decking. It’s free. We saw otters, two troops on monkeys, monitors and other lizards. Loads of butterflies and birds.\nOverall really enjoying day and a nice change."
+        },
+        {
+          "title": "Good bonding for family",
+          "text": "A nice outing and interesting cycling trip from Jetty to Chek java. Boardwalk provides many sights and animals for kids to converse on, the tower provides a good view of the island from the top"
+        },
+        {
+          "title": "Stunning countryside building",
+          "text": "After walking the boardwalks at Chek Jawa, we ate our packed lunch at the jetty next to Chek Jawa Visitor Centre (House No 1).  It was built in 1930s as a holiday retreat for the Chief Surveyor of Singapore, Landan Williams.\n\nIt is a delightful Tudor-style house with a fireplace so typical of a countryside cottage in England.  The gables are framed by timbers treated with black creosote.  It was fortunately restored in 2005 from  its dilapidated state.  It has its own jetty."
+        },
+        {
+          "title": "Avoid first bike kiosk from jetty - poor bike maintenance and customer service",
+          "text": "(This review is about a bike rental kiosk on Ubin, not about Chek Jawa. It doesn’t have its own TripAdvisor page, and many people get to Chek Jawa by cycling. My 5 stars are for Chek Jawa; 1 star for this bike kiosk.)\n\nIf you plan to rent a bike to cycle to Chek Jawa, for your own safety avoid renting from the first bicycle kiosk you see when walking in from the jetty. (It is on the right and it’s called Comfort Bicycle Rental & Trading, although this name is not prominently displayed. Shop no 18 – there’s a few bike kiosks close to each other. Photos included.) Most people rent from here because it’s the first bicycle kiosk they see and because its staff are quite proactive in inviting passersby to rent from them. But their bicycles are poorly maintained and if you run into trouble, you’re unlikely to get any help from their customer service.\n\nMy front tyre started losing air and then came completely off its rim when I was cycling (photos included). I believe this was due to a tyre that was punctured before I rented it, because when I took it that morning I noticed the front wheel was already soft (so I asked a staff member to inflate it before I took it). When I got back to the kiosk, I asked them to refund my bike rental and the cost of the shuttle van that I had to charter to bring me and the bike back to the jetty.\n\nThey refused to refund the bike rental, because I could have hit a nail when riding. (I accept that we don’t know exactly when the tyre got punctured.) But they also refused to refund my shuttle van cost of $10, saying in Chinese that my van rental had “nothing to do with them” and suggesting that I could have left my bike on the trail and walked back to the jetty instead. (I was stranded near Ah Ma's Drinks Stall on the way back from Puaka Hill, so I believe walking back would have taken me at least 30-45min.) When I insisted, they told me that they were already charging me a low rate for the bicycle ($12 per day) compared to the bicycle kiosks in East Coast Park, and that bicycle parts and maintenance were expensive. \n\nI told them that when my tyre came off, I had twice called the phone number on their receipt for help, but no one picked up. They said no one was attending to the phone because they were busy, but even then they would only have sent a shuttle van to pick me up – seemingly implying that they would still have charged me for the van. After about five to ten minutes of heated conversation, they finally agreed to give me half the van’s cost “to be fair, although we won’t do this for other people”.\n\nWhile their demeanour was very unpleasant, I’m less concerned about not getting the van’s cost refunded, and more so about their lack of interest in how the accident happened. I believe the tyre was already punctured because the front wheel was already soft when I rented it (as mentioned earlier) but also because earlier that day I had to try four different bikes before I found one that was working:\n1.\tThe first bicycle’s chain had come off. \n2.\tThe second’s back wheel brakes were not very effective (to be fair a staff member helped me to tighten them immediately, but I still wanted to change bike). \n3.\tThe third also had poor back brakes, but when I asked a staff member to help me tighten them, he said that this bicycle’s brakes were bad and brought out a fourth bike for me to try instead. \n4.\tThis was the bike with the soft front tyre which I eventually took after I asked a staff member to reinflate it. I took it because by this time my friend, who had taken the first bike she tried, had been waiting at least 15 minutes for me to find a bike.\n\nI rented the bikes at 10am on a Saturday, so it’s more likely that they don’t maintain their bikes well than that someone had returned them in poor condition. When asking for the bike rental refund I tried to tell them about their poor maintenance – how I’d tried four different bikes in the morning and how my front wheel had already been soft. But they ignored these points and kept saying I must have hit a nail when riding, otherwise the tyre would have deflated much sooner. (I believe it was a slow puncture – I managed to cycle to Chek Jawa and partway back, and only noticed the tyre was getting soft when on a detour to Puaka Hill. It came off only after I left Puaka Hill.)\n\nFortunately I was cycling slowly and on flat ground when the tyre came off. I’m afraid to think what might have happened if the tyre had come off when I was riding fast, downhill, or near other cyclists. Or if a child or an elderly person had ridden this bike. \n\nI won’t rent from this kiosk again. I’d recommend walking further into the street, where there’s at least two to three other bicycle kiosks. In particular, if you walk all the way to the end where the street opens into a clearing, there’s a standalone bicycle kiosk in a hut on the left, which gets the least business because of its location. I’ll likely try that one the next time I visit Pulau Ubin.\n\nP.S. If renting a bike on Ubin, please check your tyre pressure, brakes and that you can change gears! The last two matter because there are slopes on the way to Chek Jawa."
+        },
+        {
+          "title": "meant for those who never see mangroves before",
+          "text": "males <60yrs.& female < 55yrs.strengthen your arms,thighs & leg muscles and check the weather before you go.so happens that we went was a cloudy & windy day.a lot of bicycle-riding,pushing up and going downhill rides.can easily get heat stroke for elderly.pack grapes,guava and 1L of water to avoid dehydration.apply greaseless sunscreen and must bring sunglasses.takes 2-3hrs.to cover whole island.\ni think wild boars has been captured and relocated as they're quite dangerous ."
+        }
+      ],
+      "description": "Experience the rich ecosystems of Chek Jawa along the 1.1 km boardwalk that runs along the coast and mangrove area and get a glimpse of the rich plant and marine life.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g1644875-d2344353-Reviews-Chek_Jawa-Pulau_Ubin.html?m=66827",
+      "address_obj": {
+        "street2": "",
+        "city": "Pulau Ubin",
+        "state": "Pulau Ubin",
+        "country": "Singapore",
+        "address_string": "Pulau Ubin Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "Island",
+          "name": "Pulau Ubin",
+          "location_id": "1644875"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.40354",
+      "longitude": "103.97212",
+      "timezone": "Asia/Singapore",
+      "write_review": "https://www.tripadvisor.com/UserReview-g1644875-d2344353-Chek_Jawa-Pulau_Ubin.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "1644875",
+        "ranking_string": "#1 of 7 things to do in Pulau Ubin",
+        "geo_location_name": "Pulau Ubin",
+        "ranking_out_of": "7",
+        "ranking": "1"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "151",
+      "review_rating_count": {
+        "1": "0",
+        "2": "0",
+        "3": "8",
+        "4": "50",
+        "5": "93"
+      },
+      "photo_count": "312",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g1644875-d2344353-m66827-Reviews-Chek_Jawa-Pulau_Ubin.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Nature & Wildlife Areas",
+              "localized_name": "Nature & Wildlife Areas"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "34"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "24"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "31"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "37"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street2": "",
+        "city": "Pulau Ubin",
+        "state": "Pulau Ubin",
+        "country": "Singapore",
+        "address_string": "Pulau Ubin Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Merlion Park, Singapore: Attractions & Things to Do": [
+    {
+      "location_id": "644919",
+      "name": "Merlion Park",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/4d/a7/97/photo2jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/34/d4/0f/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/34/d4/0e/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/34/d4/0d/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/34/a7/38/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Worth a visit for the photo op",
+          "text": "Well maintained park but is crowded throughout the day due to it being a must visit location for every Singapore tourist. You can walk next to the water to the Singapore flyer in about 20 mins from here."
+        },
+        {
+          "title": "Simply Amazing",
+          "text": "Been to Singapore twice but this is my first time to visit the Merlion Park at night. It was peaceful and even more beautiful. Note that they turn off the water when it is midnight. It has a good view of the Marina Bay Sands."
+        },
+        {
+          "title": "Loved the Merlion Park and the views!",
+          "text": "I was recently at the Merlion Park, and I walked there from One Fullerton viewing deck. The walk from the MRT station (Raffles place) was incredibly easy and well marked. The Merlion view is iconic and the view of the city skyline, was absolutely awe inspiring. I loved the vibe of the merlion park and cannot wait to be back again."
+        },
+        {
+          "title": "Iconic place in Singapore",
+          "text": "The Merlion park loin / mermaid statue is world known iconic sculpture of Singapore. With water being spat out from its mouth, representing the original fishing village of Singapore.\nA very busy area for tourists on the harbour foreshore & a must see place in Singapore."
+        },
+        {
+          "title": "SG icon",
+          "text": "Place with so many tourist, iconic, well maintained and cleaned periodically. So many people just take picture with the icon or place to gathering. Near bus or mrt, easy to access"
+        }
+      ],
+      "description": "Standing at 8.6 metres high and weighing 70 tonnes, the Merlion statue has a lion’s head and a fish’s body, and is housed here in this 2,500 square metre park.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d644919-Reviews-Merlion_Park-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 Fullerton Road One Fullerton",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "049213",
+        "address_string": "1 Fullerton Road One Fullerton, Singapore 049213 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.286796",
+      "longitude": "103.85451",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6736 6622",
+      "website": "http://www.yoursingapore.com",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d644919-Merlion_Park-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#36 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "36"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "9724",
+      "review_rating_count": {
+        "1": "64",
+        "2": "186",
+        "3": "1662",
+        "4": "4061",
+        "5": "3751"
+      },
+      "photo_count": "9629",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d644919-m66827-Reviews-Merlion_Park-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Monuments & Statues",
+              "localized_name": "Monuments & Statues"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "15622413",
+          "name": "Clifford Pier"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "365"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "2488"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "1217"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "2353"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "1732"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "TopAttractions"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        },
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "1 Fullerton Road One Fullerton",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "049213",
+        "address_string": "1 Fullerton Road One Fullerton, Singapore 049213 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Marina Bay SandsÂ® SkyPark": [
+    {
+      "location_id": "1177497",
+      "name": "Marina Bay",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/d7/53/1f/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/b8/fa/31/photo7jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/b8/fa/30/photo6jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/b8/fa/2e/photo4jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/b8/fa/2f/photo5jpg.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Symbolically Iconic",
+          "text": "No matter where you view it, the Marina Bay Sands building is iconic Singapore. Views out from the bay itself or Gardens By The Bay will be sure to delight. Selfies galore!"
+        },
+        {
+          "title": "Great Area to Stay if You Enjoy Walking a Waterfront Promenade",
+          "text": "A very pretty area to walk particularly in evening when city lights up. Mandarin Oriental hotel is very lovley, Makansutra Gluttons Bay's 12 hawker stalls have a great range of top-quality food, waterfront bars with live music and casual food and drinks make for a great evening. Walking fully around Marina Bay takes about an hour and ten minutes. MRT statins take you around the rest of the city easily."
+        },
+        {
+          "title": "Amazing",
+          "text": "Marina Bay is an absolutely stunning destination! The breathtaking skyline, iconic landmarks like Marina Bay Sands and Gardens by the Bay, and the vibrant atmosphere make it a must-visit. Whether you’re enjoying a relaxing stroll along the waterfront, watching the mesmerizing light shows, or dining at world-class restaurants, there’s always something magical about this place. The combination of modern architecture, beautiful nature, and lively nightlife creates an unforgettable experience. If you’re visiting Singapore, Marina Bay is definitely a highlight you shouldn’t miss!"
+        },
+        {
+          "title": "Mild-Mannered Comfortable Asian Felt Crazy Rich",
+          "text": "I booked a room overlooking the Gardens by the Bay to celebrate our wedding anniversary in Singapore during Valentine's Day for 2 nights. We were able to check in early & Andy - the receptionist really came through for us! He recognized from my booking that we're celebrating our anniversary so he upgraded us to a suite room, with the same view overlooking the Gardens on 30th floor. OMG, our suite room was spectacular!!! The housekeeping staff was also very efficient and welcoming. Making sure that we're always taken care of as far as stocking our room every time we're gone, the things we used gets replaced & cleaned up. We're glad to spend this much booking this hotel. It's a one in a lifetime experience. The infinity pool was also amazing! I would definitely recommend to everyone to celebrate their special day here at the MBS hotel. Everything is perfect and breathtaking!!!\n\nThe Rise buffet was amazing! We had dinner and very pleased with the food selection and service. Make sure you sign up for Marina Bay Sands app, you get rewards points/cash that you can use to any of their restaurants & stores, just make sure to present your membership number every time you pay. \n\nLastly,  hands up  to Andy at the hotel reception. He really came through for us. Made our anniversary very memorable and special!!! Employee of the Year"
+        },
+        {
+          "title": "In the future, I would really want to stay at this hotel.",
+          "text": "I was given the opportunity to tour the Marina Bay Sands Hotel. It was breathtaking. I was allowed to go outdoors and enjoy the spectacle at night. The artwork and soundtrack were amazing. I also went to the top-floor Wolfgang Puck restaurant's bar. The beverages were excellent, the service was excellent, and the view was breathtaking!"
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d1177497-Reviews-Marina_Bay-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Marina Boulevard",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018980",
+        "address_string": "Marina Boulevard, Singapore 018980 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.28779",
+      "longitude": "103.866554",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6329 3535",
+      "website": "https://www.ura.gov.sg/Corporate/Get-Involved/Shape-A-Distinctive-City/Explore-Our-City/Marina-Bay",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d1177497-Marina_Bay-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#5 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "5"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "13200",
+      "review_rating_count": {
+        "1": "39",
+        "2": "59",
+        "3": "603",
+        "4": "3885",
+        "5": "8614"
+      },
+      "photo_count": "9435",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d1177497-m66827-Reviews-Marina_Bay-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Marinas",
+              "localized_name": "Marinas"
+            },
+            {
+              "name": "Bodies of Water",
+              "localized_name": "Bodies of Water"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622527",
+          "name": "Central"
+        },
+        {
+          "location_id": "7291605",
+          "name": "Marina Bay"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "881"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "4122"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "1275"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "2473"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "2068"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "TopAttractions"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        },
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "Marina Boulevard",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "018980",
+        "address_string": "Marina Boulevard, Singapore 018980 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Resorts World Sentosa, Singapore": [
+    {
+      "location_id": "1994850",
+      "name": "Resorts World Sentosa Casino",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/1c/aa/00/46/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0c/a3/89/1b/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/cd/66/94/resorts-world-sentosa.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/13/1a/46/c8/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/42/94/81/dsc-0548-largejpg.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Better Designated Areas for Non-Smokers. Much Better Than the MBS Casino!",
+          "text": "My Uncle and I visited this casino for the first time in April 2024. We had already gone to the MBS casino on the previous night. We only have to get through 2 different security officers to enter the RWS casino, compared to 4 security check points to enter the MBS casino. The RWS casino also has a proper and genuine smoke-free area for its patrons, which is infinitely better than the MBS casino! We are non-smokers and almost died of smoke inhalation in the MBS casino the night before, therefore this was a welcome respite for us. My Uncle played the roulette tables, I played the slot machines. The is a better variety of slot machines here. Both of us walked away with small winnings after several hours spent here."
+        },
+        {
+          "title": "Bad treatment by a rude staff at entrance",
+          "text": "We visited the casino on 29 March 2024 around noon time. As foreign visitors, we have to get our passport and digital arrival card checked before entering the casino. We encountered a staff at the entry gate named Sam Liau who was extremely rude and disrespectful.\n\nAs first time visitors, we were new to the process. My parents gave him both passports and in a condescending and rude tone he told them to hold their own passport and he got extremely frustrated when my parents showed him the arrival card but couldn’t tell him exactly which of the arrival card (both in the same phone) is my mum’s and which is my dad’s. He rolled his eyes and rudely tell my parents to get away from the entrance and go back of the queue. This would have been a quick check on the passport number against the arrival card for two persons and there were only one couple queuing behind them. \n\nIt’s ok to tell my parents to let the couple behind them to go first and to check which arrival card is whose but he could ask in a nice manner. His attitude was appalling treating my elderly parents who are in their late 60s like criminals. His tone of voice/demeanor and his treatment was so harsh that we were shocked. This is a hospitality business and in no way customers should be treated as such that we felt so unwelcoming. It’s not a fault of visitors to be new to the process nor a fault of elderly to be a bit slow with phones/digital arrival card. I thought the whole point of having a staff there was to help and check?\n\nIt seems like Sam Liau didn’t want to do the simple job of checking arrival card against passport and didn’t like his job much. It’s ok too but don’t treat customers especially elderly so disrespectfully and take it out on them - the lack of manners is truely shocking. Very bad experience. We won’t be returning again. We will go to the other casino where we feel more welcomed."
+        },
+        {
+          "title": "Certainly nicer than MBS casino in my view",
+          "text": "Yes, the entry procedure here is an identically arduous and ridiculously over-the-top as that which the Singaporean government runs at the MBS casino, however once inside this Sentosa casino has a much more relaxed and nicer vibe in my view than the other one at MBS.  I also found the variety of machines to be a bit better here than at MBS, although still lacking in machine variety when compared to most other casinos worldwide.  The layout of this casino also made the smokiness not nearly as bad as it was at MBS.  And I was satisfied with the inexpensive and easy to locate food outlets.  The gamblers were also not mostly trashy like I found them to be at MBS.  Still not great here, but certainly better than MBS in my view, and quite acceptable if you want to do some machine gambling while in Singapore.  Note though that we only played slots/pokies on this trip/visit and not table games."
+        },
+        {
+          "title": "Not worth the hassle unless you're committed to gambling",
+          "text": "I grew up in Vegas, so I guess I have a different perspective on casinos.  I really just wanted to check out the place.  I didn't plan to gamble more than a couple dollars.  This time I had my passport.  In Cannes, I was refused entry because I wasn't carrying it.  But this casino has a second barrier.  You have to be pre-approved in a separate area and then bring proof that you're worthy of entry. \n\n I assume, a credit check or at least a check of my credit card limit was in order.  I passed.  This was too much hassle just to see how the place varies from Vegas casinos.  Their loss."
+        },
+        {
+          "title": "Foreigners,  take your passport ",
+          "text": "Resorts Casino is on Sentosa Island.   Do not take the cable car as it takes you nowhere near Resorts.   The MRT is more convenient as it connects to the casino.   You need a passport as a foreigner to enter the Casino.  There are 2 levels of shops and restaurants just outside Casino entrances.   Wheelchair accessible.   "
+        }
+      ],
+      "description": "Owned and operated by Asia's largest gaming operator, Resorts World Sentosa is unrivalled in its intimate knowledge of Asian gaming preferences. The place brims with activity 24/7 and is complemented by unparalleled customer privileges. Our trained croupiers and hand-picked Guests Services Ambassadors will ensure our customers get an enjoyable and memorable experience.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d1994850-Reviews-Resorts_World_Sentosa_Casino-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "8 Sentosa Gateway",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "098269",
+        "address_string": "8 Sentosa Gateway, Singapore 098269 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.256984",
+      "longitude": "103.82027",
+      "timezone": "Asia/Singapore",
+      "email": "enquiries@rwsentosa.com",
+      "phone": "+65 6577 8000",
+      "website": "https://www.gentingrewards.com.sg/en/home/casino",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d1994850-Resorts_World_Sentosa_Casino-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#120 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "120"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "418",
+      "review_rating_count": {
+        "1": "17",
+        "2": "23",
+        "3": "92",
+        "4": "179",
+        "5": "107"
+      },
+      "photo_count": "151",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d1994850-m66827-Reviews-Resorts_World_Sentosa_Casino-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0000"
+            },
+            "close": {
+              "day": 1,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0000"
+            },
+            "close": {
+              "day": 2,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0000"
+            },
+            "close": {
+              "day": 3,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0000"
+            },
+            "close": {
+              "day": 4,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0000"
+            },
+            "close": {
+              "day": 5,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0000"
+            },
+            "close": {
+              "day": 6,
+              "time": "2359"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0000"
+            },
+            "close": {
+              "day": 7,
+              "time": "2359"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 00:00 - 23:59",
+          "Tuesday: 00:00 - 23:59",
+          "Wednesday: 00:00 - 23:59",
+          "Thursday: 00:00 - 23:59",
+          "Friday: 00:00 - 23:59",
+          "Saturday: 00:00 - 23:59",
+          "Sunday: 00:00 - 23:59"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "fun_games",
+          "localized_name": "Fun & Games"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "casinos_gaming",
+          "localized_name": "Casinos & Gambling"
+        },
+        {
+          "name": "activities",
+          "localized_name": "Activities"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Casinos & Gambling",
+          "localized_name": "Casinos & Gambling",
+          "categories": [
+            {
+              "name": "Casinos",
+              "localized_name": "Casinos"
+            }
+          ]
+        },
+        {
+          "name": "Fun & Games",
+          "localized_name": "Fun & Games",
+          "categories": [
+            {
+              "name": "Casinos",
+              "localized_name": "Casinos"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "12"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "94"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "77"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "73"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "90"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "8 Sentosa Gateway",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "098269",
+        "address_string": "8 Sentosa Gateway, Singapore 098269 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Singapore Garden & Singapore Park": [
+    {
+      "location_id": "310900",
+      "name": "Singapore Botanic Gardens",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/7f/e5/ce/beautiful-botanic-gardens.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/45/a6/b8/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/45/a6/b7/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/45/a6/b6/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/45/a6/b5/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Beautiful Day Out",
+          "text": "Beautiful gardens with separate orchid house, I visited the Botanical Gardens as part of a City tour, we only had about 90 minutes, you definitely need most of a day to really enjoy the experience"
+        },
+        {
+          "title": "If only...........",
+          "text": "Never to be missed, we spent two mornings at the Botanic Gardens, both times arriving just as dawn was breaking courtesy of the MRT.  This allowed a full morning to be spent around the gardens, taking in breakfast after a couple of hours and retiring back to our son’s apartment around lunchtime when it became too hot and humid.\n\nSo much has been written about the gardens, there is no real need to add more except to confirm that they are world class, beautifully maintained by a veritable army of gardeners and, amazingly, apart from the orchid garden, free of charge.  They are a favourite with joggers, dog walkers and, as the morning wears on, organised school visits and crocodiles of tourists.  Busy, but never crowded.\n\nThere is always a lot of wildlife around but on our first visit, we did not see Singapore’s famous film-star otters.  There was lots of advice from people about where they were yesterday, or their usual routes between ponds, and there were  birds, terrapins and salamanders a-plenty; but no otters.  Maybe, being film stars, their agent only lets them come out for appearance money these days.\n\nThe second visit also started early and my wife decided that it was necessary to “discuss” which platform to use at Downtown MRT station to get to the gardens.  (Same as on the previous occasion, one might have thought.)  Naturally, she favoured the “other” one.  By the time the discussion was over, we descended to the platform to see the train vanishing down the tunnel.  No matter, it was only two minutes until the next one.  \n\nHowever, they were an important two minutes.  We strolled into the gardens accompanying the usual joggers and dog walkers who take advantage of the cool dawn period, and as we rounded the corner towards the northernmost pond, we were just in time to see the back legs and tail of an otter slip into the water fifty yards away.  By the time we made that spot, the only trace of otters were about half a dozen tiny bow waves at the other side of the pond heading for the reeds.  If only we had not been held up by the “discussion” and missed the train!  Oh well; next time we are in Singapore perhaps.\n\nAnyway, it was still a most pleasing morning around the gardens and they remain, even with elusive otters, a “must see” location in Singapore."
+        },
+        {
+          "title": "Lovely way to spend day in gardens",
+          "text": "We had a great day at the gardens.  They are great to see and lots of different plants and trees and lovely views.\n\nIt did start raining heavily when we were there but they do have shelters dotted around the gardens to shelter in but recommend taking your umbrella.\n\nWe particularly enjoyed the food at the food hall - it was v quiet when we were there but of really good standard."
+        },
+        {
+          "title": "Blooming with wildlife",
+          "text": "My family and I enjoyed a peaceful walk around the Botanical gardens of Singapore. During our pleasant stroll we saw a monitor lizard, a terrapin and many other amazing creatures. I guarantee that you will see some amazing wildlife and enjoy your walk."
+        },
+        {
+          "title": "Yes- It Really Is a Must See",
+          "text": "Yes- it’s beautiful- the year round growing season makes it possible to walk around a blooming jungle. The orchid area was too crowded and hot for me- the gardens are extensive and well maintained but it’s a lengthy walk- mostly level with relatively frequent seating areas . No internal transportation- occasional birds and animals. There’s a Hop on Bus stop near the orchid area."
+        }
+      ],
+      "description": "This national park is open daily and features beautiful lakes, animals, flowers and plants, including one of the region's first rubber tree orchards.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d310900-Reviews-Singapore_Botanic_Gardens-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 Cluny Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "259 569",
+        "address_string": "1 Cluny Road, Singapore 259 569 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.313855",
+      "longitude": "103.81592",
+      "timezone": "Asia/Singapore",
+      "email": "nparks_sbg_visitor_services@nparks.gov.sg",
+      "phone": "1800 471 7300",
+      "website": "https://www.nparks.gov.sg/SBG",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d310900-Singapore_Botanic_Gardens-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#3 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "3"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "20149",
+      "review_rating_count": {
+        "1": "37",
+        "2": "66",
+        "3": "827",
+        "4": "4920",
+        "5": "14299"
+      },
+      "photo_count": "16700",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d310900-m66827-Reviews-Singapore_Botanic_Gardens-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0500"
+            },
+            "close": {
+              "day": 1,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0500"
+            },
+            "close": {
+              "day": 2,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0500"
+            },
+            "close": {
+              "day": 3,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0500"
+            },
+            "close": {
+              "day": 4,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0500"
+            },
+            "close": {
+              "day": 5,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0500"
+            },
+            "close": {
+              "day": 6,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0500"
+            },
+            "close": {
+              "day": 7,
+              "time": "0000"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 05:00 - 00:00",
+          "Tuesday: 05:00 - 00:00",
+          "Wednesday: 05:00 - 00:00",
+          "Thursday: 05:00 - 00:00",
+          "Friday: 05:00 - 00:00",
+          "Saturday: 05:00 - 00:00",
+          "Sunday: 05:00 - 00:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Parks",
+              "localized_name": "Parks"
+            },
+            {
+              "name": "Gardens",
+              "localized_name": "Gardens"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622560",
+          "name": "Tyersall"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "844"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "7235"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "2330"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "3739"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "2863"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "TopAttractions"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        },
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "1 Cluny Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "259 569",
+        "address_string": "1 Cluny Road, Singapore 259 569 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Sungei Buloh": [
+    {
+      "location_id": "315468",
+      "name": "Sungei Buloh Wetland Reserve",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/79/27/9e/photo2jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/29/32/a0/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/29/32/9f/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/29/32/9e/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/29/32/9d/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Wild Wonderland (in places)",
+          "text": "The Coastal walk from the Visitor Centre was uneventful but once we got to the loops near the Wetland Centre, we saw lots.  Crocodiles, water monitors, king cobra, bittern, sunbirds, hornbill and more. A wonderful place to visit. Taxi from Sentosa (via Grab app) was only about $35 each way."
+        },
+        {
+          "title": "Pleasant day",
+          "text": "We caught the train to Kranji, then a bus to the reserve. A ranger was there at the entrance to point out places of interest on a map. He also showed us the bats, which we would have missed if he had not been there. \nWe walked around through the pods (interesting designs) to the Wetland Centre. Then continued around the loop at the tidal ponds, the Migratory Bird trail. There were not many birds around when we were there. We did not see any crocodiles, but did see numerous monitor lizards.  Few people around too!\nAn interesting day trip to do and worth the effort. Would probably return on another visit to Singapore."
+        },
+        {
+          "title": "A hidden gem and a lucky day out..",
+          "text": "We visited Sungei Buloh on Christmas Eve and we had a lucky day out spotting crocodiles (4 times), monitor lizards (many times), herons and eagles, snakes (3 times) in our 3 hours of exploration around the reserve.  There wasn't many visitors and the place is tranquil.  One has to look up and down and around to spot the wild lives. This is not a zoo so spotting is not guaranteed.  \n\nThe regular visitors and photographers to the Reserve are generally helpful and would alert you to their sightings.\n\nTips:\n1) Take the MRT to Choa Chu Kang Station and transfer to Bus No. 925 to the entrance of the Reserve.  2 minutes walk from the bus stop to the entrance.  \n2) Free entrance.\n3) Close at 7pm.  Advisable to visit in the morning.\n4) Bring water and snacks along.  A binocular would be good."
+        },
+        {
+          "title": "Beautiful natural area",
+          "text": "A beautiful and diverse habitat to visit. The reserve is home to many kinds of plants and animals in the forests and mangroves.  We were able to see a monitor lizard, a king cobra, many species of birds, mudskippers, mangrove horseshoe crabs among others. Crocodiles and monkeys are found there, but we weren't lucky enough to see them during our visit."
+        },
+        {
+          "title": "Enjoyable visit to Sungei Buloh",
+          "text": "It was our first visit to the Sungei Buloh Wetland Reserve. We arrived on a Friday evening around 6.10pm. It was relatively quiet, lots of parking space and just a handful of visitors.\n\nOne of the staff reminded us that the park closed at 7.00pm. Given that we had just about 40 minutes of time to explore this place, we decided to keep to the coastal trail.\n\nThere are pods dotted along the boardwalk which are great lookout points. We visited the Fantail Pod and Eagle Point. Both offered stunning views over Strait of Johor.\n\nWe didn’t spot any crocodiles or eagles. Will have to come back another time.\n\nWhile there are buses that ply the Kranji MRT Station and Sungei Buloh route, I think it’s much better to drive there."
+        }
+      ],
+      "description": "This 200-acre reserve, situated north of the island, is home to over 150 species of rare and exotic birds.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d315468-Reviews-Sungei_Buloh_Wetland_Reserve-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "301 Neo Tiew Crescent",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "718925",
+        "address_string": "301 Neo Tiew Crescent, Singapore 718925 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.446398",
+      "longitude": "103.72306",
+      "timezone": "Asia/Singapore",
+      "email": "info@sbwr.org.sg",
+      "phone": "+65 6794 1401",
+      "website": "https://beta.nparks.gov.sg/visit/parks/park-detail/sungei-buloh-wetland-reserve",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d315468-Sungei_Buloh_Wetland_Reserve-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#33 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "33"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "559",
+      "review_rating_count": {
+        "1": "2",
+        "2": "11",
+        "3": "41",
+        "4": "207",
+        "5": "298"
+      },
+      "photo_count": "1181",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d315468-m66827-Reviews-Sungei_Buloh_Wetland_Reserve-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0700"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0700"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0700"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0700"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0700"
+            },
+            "close": {
+              "day": 5,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0700"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0700"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 07:00 - 19:00",
+          "Tuesday: 07:00 - 19:00",
+          "Wednesday: 07:00 - 19:00",
+          "Thursday: 07:00 - 19:00",
+          "Friday: 07:00 - 19:00",
+          "Saturday: 07:00 - 19:00",
+          "Sunday: 07:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Nature & Wildlife Areas",
+              "localized_name": "Nature & Wildlife Areas"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622352",
+          "name": "Lim Chu Kang"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "19"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "106"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "69"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "107"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "125"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "301 Neo Tiew Crescent",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "718925",
+        "address_string": "301 Neo Tiew Crescent, Singapore 718925 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "S.E.A. Aquarium": [
+    {
+      "location_id": "4009739",
+      "name": "S.E.A. Aquarium",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/33/94/49/sea-aquarium.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/03/f7/ac/9f/sea-aquarium.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/53/7d/09/ocean-dome.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/53/7c/f9/shark-seas.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/33/94/68/sea-aquarium.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Lovely aquarium but dolphin exhibit unethical",
+          "text": "There are many wondrous, beautiful things to see at this aquarium. The facilities and diversity of fish are incredible.\nI rarely write a review unless it’s 5 stars - however after viewing the dolphins it was utterly awful to see such intelligent creatures confined to an unnatural environment. Shocking and saddening. I sincerely wish they are released to the wild and dolphin enclosures like this cease to exist anywhere in the world."
+        },
+        {
+          "title": "Great value and hope you get Ying as your guide!",
+          "text": "I'm from California, so I had to gage the aquarium against SeaWorld and Monterey Bay Aquarium. This aquarium is still a great value. I went on the VIP tour, and got a spectacular guide named Ying, who made sure to point out everything she could. \n\nShe was very knowledgeable with answering questions as well. She even tested my understanding by asking me questions back.\n\nSometimes the fish were not cooperative and she was patient to make sure I saw what I needed (we sat and looked for the Tiger Shark for a while). :)\n\nThe dolphin experience was fun, would be more fun if I was 40 years younger. The kids will really love this. Still managed to put me in a good mood when the dolphin laughed with me.\n\nThe behind the scenes tours were great as well, you get to see the hatcheries of the jellyfish and plankton, and even the coral.\n\nAll in all a great value, but Ying made it really memorable! Thanks!!!"
+        },
+        {
+          "title": "Wonderful experience",
+          "text": "This aquarium,like much of Singapore is very well though out...very clean and very easy to sea all the marine life. Educational"
+        },
+        {
+          "title": "Hard time traversing the aquarium",
+          "text": "This place is a very bright and wonderful place, the sea life was very interesting to look in awe at. However, I found it difficult to traverse the aquarium and the exhibits.\nMe and my family were honestly very dumbfounded at where we should go."
+        },
+        {
+          "title": "Need improvement on customer service",
+          "text": "customer service like horrendous!! didnt expect this from such a renowned attraction. i expected much more. 2 stars for the attractions, 0 stars for CUSTOMER SERVICE!!"
+        }
+      ],
+      "description": "Enter and explore the marine realm of S.E.A. Aquarium, home to more than 100,000 marine animals of over 1,000 species, across into 50 different habitats, each one as fascinating as the next. It's an experience you won’t forget.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294264-d4009739-Reviews-S_E_A_Aquarium-Sentosa_Island.html?m=66827",
+      "address_obj": {
+        "street1": "8 Sentosa Gateway",
+        "street2": "Resorts World Sentosa",
+        "city": "Sentosa Island",
+        "state": "Sentosa Island",
+        "country": "Singapore",
+        "postalcode": "098269",
+        "address_string": "8 Sentosa Gateway Resorts World Sentosa, Sentosa Island 098269 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "Island",
+          "name": "Sentosa Island",
+          "location_id": "294264"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.258214",
+      "longitude": "103.82062",
+      "timezone": "Asia/Singapore",
+      "email": "enquiries@rwsentosa.com",
+      "website": "http://www.rwsentosa.com/en/attractions/sea-aquarium?utm_source=tripadvisor_seaa&utm_medium=affiliates&utm_campaign=businesslistings",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294264-d4009739-S_E_A_Aquarium-Sentosa_Island.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294264",
+        "ranking_string": "#6 of 29 things to do in Sentosa Island",
+        "geo_location_name": "Sentosa Island",
+        "ranking_out_of": "29",
+        "ranking": "6"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "6907",
+      "review_rating_count": {
+        "1": "78",
+        "2": "157",
+        "3": "735",
+        "4": "2245",
+        "5": "3692"
+      },
+      "photo_count": "9378",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294264-d4009739-m66827-Reviews-S_E_A_Aquarium-Sentosa_Island.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 19:00",
+          "Tuesday: 10:00 - 19:00",
+          "Wednesday: 10:00 - 19:00",
+          "Thursday: 10:00 - 19:00",
+          "Friday: 10:00 - 19:00",
+          "Saturday: 10:00 - 19:00",
+          "Sunday: 10:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "zoos_aquariums",
+          "localized_name": "Zoos & Aquariums"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Zoos & Aquariums",
+          "localized_name": "Zoos & Aquariums",
+          "categories": [
+            {
+              "name": "Aquariums",
+              "localized_name": "Aquariums"
+            }
+          ]
+        },
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Aquariums",
+              "localized_name": "Aquariums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "97"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "1618"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "345"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "3137"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "796"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "8 Sentosa Gateway",
+        "street2": "Resorts World Sentosa",
+        "city": "Sentosa Island",
+        "state": "Sentosa Island",
+        "country": "Singapore",
+        "postalcode": "098269",
+        "address_string": "8 Sentosa Gateway Resorts World Sentosa, Sentosa Island 098269 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Singapore Botanic Gardens": [
+    {
+      "location_id": "310900",
+      "name": "Singapore Botanic Gardens",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/7f/e5/ce/beautiful-botanic-gardens.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/45/a6/b8/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/45/a6/b7/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/45/a6/b6/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/45/a6/b5/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Beautiful Day Out",
+          "text": "Beautiful gardens with separate orchid house, I visited the Botanical Gardens as part of a City tour, we only had about 90 minutes, you definitely need most of a day to really enjoy the experience"
+        },
+        {
+          "title": "If only...........",
+          "text": "Never to be missed, we spent two mornings at the Botanic Gardens, both times arriving just as dawn was breaking courtesy of the MRT.  This allowed a full morning to be spent around the gardens, taking in breakfast after a couple of hours and retiring back to our son’s apartment around lunchtime when it became too hot and humid.\n\nSo much has been written about the gardens, there is no real need to add more except to confirm that they are world class, beautifully maintained by a veritable army of gardeners and, amazingly, apart from the orchid garden, free of charge.  They are a favourite with joggers, dog walkers and, as the morning wears on, organised school visits and crocodiles of tourists.  Busy, but never crowded.\n\nThere is always a lot of wildlife around but on our first visit, we did not see Singapore’s famous film-star otters.  There was lots of advice from people about where they were yesterday, or their usual routes between ponds, and there were  birds, terrapins and salamanders a-plenty; but no otters.  Maybe, being film stars, their agent only lets them come out for appearance money these days.\n\nThe second visit also started early and my wife decided that it was necessary to “discuss” which platform to use at Downtown MRT station to get to the gardens.  (Same as on the previous occasion, one might have thought.)  Naturally, she favoured the “other” one.  By the time the discussion was over, we descended to the platform to see the train vanishing down the tunnel.  No matter, it was only two minutes until the next one.  \n\nHowever, they were an important two minutes.  We strolled into the gardens accompanying the usual joggers and dog walkers who take advantage of the cool dawn period, and as we rounded the corner towards the northernmost pond, we were just in time to see the back legs and tail of an otter slip into the water fifty yards away.  By the time we made that spot, the only trace of otters were about half a dozen tiny bow waves at the other side of the pond heading for the reeds.  If only we had not been held up by the “discussion” and missed the train!  Oh well; next time we are in Singapore perhaps.\n\nAnyway, it was still a most pleasing morning around the gardens and they remain, even with elusive otters, a “must see” location in Singapore."
+        },
+        {
+          "title": "Lovely way to spend day in gardens",
+          "text": "We had a great day at the gardens.  They are great to see and lots of different plants and trees and lovely views.\n\nIt did start raining heavily when we were there but they do have shelters dotted around the gardens to shelter in but recommend taking your umbrella.\n\nWe particularly enjoyed the food at the food hall - it was v quiet when we were there but of really good standard."
+        },
+        {
+          "title": "Blooming with wildlife",
+          "text": "My family and I enjoyed a peaceful walk around the Botanical gardens of Singapore. During our pleasant stroll we saw a monitor lizard, a terrapin and many other amazing creatures. I guarantee that you will see some amazing wildlife and enjoy your walk."
+        },
+        {
+          "title": "Yes- It Really Is a Must See",
+          "text": "Yes- it’s beautiful- the year round growing season makes it possible to walk around a blooming jungle. The orchid area was too crowded and hot for me- the gardens are extensive and well maintained but it’s a lengthy walk- mostly level with relatively frequent seating areas . No internal transportation- occasional birds and animals. There’s a Hop on Bus stop near the orchid area."
+        }
+      ],
+      "description": "This national park is open daily and features beautiful lakes, animals, flowers and plants, including one of the region's first rubber tree orchards.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d310900-Reviews-Singapore_Botanic_Gardens-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 Cluny Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "259 569",
+        "address_string": "1 Cluny Road, Singapore 259 569 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.313855",
+      "longitude": "103.81592",
+      "timezone": "Asia/Singapore",
+      "email": "nparks_sbg_visitor_services@nparks.gov.sg",
+      "phone": "1800 471 7300",
+      "website": "https://www.nparks.gov.sg/SBG",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d310900-Singapore_Botanic_Gardens-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#3 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "3"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "20149",
+      "review_rating_count": {
+        "1": "37",
+        "2": "66",
+        "3": "827",
+        "4": "4920",
+        "5": "14299"
+      },
+      "photo_count": "16700",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d310900-m66827-Reviews-Singapore_Botanic_Gardens-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0500"
+            },
+            "close": {
+              "day": 1,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0500"
+            },
+            "close": {
+              "day": 2,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0500"
+            },
+            "close": {
+              "day": 3,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0500"
+            },
+            "close": {
+              "day": 4,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0500"
+            },
+            "close": {
+              "day": 5,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0500"
+            },
+            "close": {
+              "day": 6,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0500"
+            },
+            "close": {
+              "day": 7,
+              "time": "0000"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 05:00 - 00:00",
+          "Tuesday: 05:00 - 00:00",
+          "Wednesday: 05:00 - 00:00",
+          "Thursday: 05:00 - 00:00",
+          "Friday: 05:00 - 00:00",
+          "Saturday: 05:00 - 00:00",
+          "Sunday: 05:00 - 00:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Parks",
+              "localized_name": "Parks"
+            },
+            {
+              "name": "Gardens",
+              "localized_name": "Gardens"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622560",
+          "name": "Tyersall"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "844"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "7235"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "2330"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "3739"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "2863"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice Best of the Best",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_bob_2024_L.png"
+          },
+          "categories": [
+            "TopAttractions"
+          ],
+          "display_name": "Travelers Choice Best of the Best"
+        },
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "1 Cluny Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "259 569",
+        "address_string": "1 Cluny Road, Singapore 259 569 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Singapore Zoo: Attractions & Things to Do": [
+    {
+      "location_id": "324542",
+      "name": "Singapore Zoo",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/1f/d8/92/9b/rhino-feeding.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0f/f1/11/55/free-ranging-orangutans.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/22/1b/41/db/retail-shop-singapore.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1f/d8/92/c8/giraffe-feeding.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1f/d8/92/b6/slither-down-to-reptopia.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Breakfast at the Zoo",
+          "text": "loved the whole experience of Breakfast At The Zoo.  The younger family members were able to interact with several animals. The meal was great and we saw the Sealion Show afterwards.  Unfortunately it was too humid to spend much more time there, but still very worthwhile."
+        },
+        {
+          "title": "Visions of the future that come from an understanding of the past and the inter-connectivity of life on Earth.",
+          "text": "Review of Singapore Zoo\n\nThis was our second visit to Singapore Zoo in two years and we remain as committed to our earlier findings as those of the current day …. The zoo provides an excellent opportunity to catch a glimpse of the complexity of the natural world that surrounds us. Besides looking at the animals in their protective enclosures there’s the underlying messages for conservation, value and appreciation that an entertaining day at the zoo provides. It helps to emphasize the unnatural balance of people worldwide within the demand for resources of land, materials, food, water and living space … with much the same requirements for the other creatures with which we share the planet.\n\nThe messages are there for those who seek them except it’s a lot to ask when you’ve a day out with the kids/family and you’re enjoying the pleasures of seeing these animals, bird, etc. in as natural an environment that the zoo can provide in the estimated 28 ha available. Here it is that you’ve an opportunity of educating/introducing those same kids to those same responsibilities that you’ve had for much of your life …. leaving space for the other species. The challenges of doing this with a global population of 8B that is expected to peak at 10B by the second half of the 21st C. remains for future generations (including those kids with you and their descendants). The zoo handles these messages well.\n\nWhilst the traditional animal enclosures – looking, at times, rather dated and tired – provide the basis of the day’s exploration, there may also have been a lean towards entertainment of a Disneyesque kind during the time since we were last there. We watched the kids being kangaroos on a timed ‘leaping pad’ (measuring leaps/distance/time), other kids running up/down a couple of boards with foot holds across them – again, against the clock (4 secs being the fastest) and still other kids testing their personal strength by lifting buckets on pulleys with different loadings. We don’t remember those features from earlier. \n\nThe food centres – zoo entrance, tram terminal and KFC-centre – remain as popular as ever. Larger? More investment? Who knows? Sure, people expect to find facilities of this kind. Have there been similar animal-focussed investment in the modern era? There seems to have been more focus upon entertainment activities associated with ‘wild animals’ including night life, river ventures and bird life rides/worlds. In the pipeline is a rainforest world. Where does the traditional scientific appreciation of ‘wildlife’ become absorbed into ‘managed wildlife’ because that may be the likely future for the original indigenous fauna (and flora) everywhere. The Wild Africa section of the zoo is a case in point. All wildlife in Africa is currently at risk of becoming lost as a result of expanding human populations, poverty, insufficient investment and mixed priorities on the part of national governments. The traditional images of Africa remain a reality of earlier times. Wildlife is in decline everywhere on the continent. Singapore zoo and others with a similar vision focus upon domestic breeding programs and the re-introduction/management of species in the wild – white rhino and Rothschild giraffe are two examples of where the zoo has been successful.\n\nMore’s the pity that, as a species, we have been so careless, lacking in understanding and appreciation of the animals, birds, insects, plants and other lifeforms around us and upon which we remain dependent. Messages such as this are found throughout the Zoo when describing the animals that are available, the loss of habitat (and particularly in regional Asia) where, in recent times, plantation agriculture has been replacing the original forests that once provided home and sustenance for animals in the Zoo – orangutans, gharials, tigers, Asian rhinos, Asian hippopotamus and others. There’s a pertinent and really sad message of this kind in the Tiger compound describing the demise of the tiger across Asia – just two native homes remain from the entire Asian continent because of persecution/hunting from the 1970s-on. Once found from the Caspian Sea to Eastern China, indigenous tigers can now only be found in India and Malaysia. There are estimated <3,000 tigers in the wild and - all this - has happened during my lifetime.\n\nSo, some serious messages for the future of the species on show at Singapore Zoo, but also some emphasis on the value of national investments of this kind as part of educating everyone (starting with the kids) that they/we are simply one of many species within the fabric of Life on Earth that helps to sustain us. Respect, understanding, science, knowledge and education underly the entertainment value of the Zoo.\n\nIf you live in Singapore, ensure that you support this national icon with an occasional visit. If you’re travelling through, here’s an expensive but highly recommended day that will provide a reasonable/confidential/self-assured vision that people of the future may be able to live in an urban/built environment that has come to terms with a sustainable world – for all species.\n\nPeter Steele\n21 June 2024"
+        },
+        {
+          "title": "One of the world’s best zoos",
+          "text": "Very well maintained with a large number of animals. The elephants and the giraffes were the show stoppers for my kid. They have a decent number of snack zones sprinkled throughout the park. Would highly recommend to make use of the zoo train that they have to get around."
+        },
+        {
+          "title": "Ethical zoo with free reigning animals. Amazing day out.",
+          "text": "Had an amazing day at the zoo. We are not massive zoo people as they can often be quite sad for the animals but this place felt ethical. The animals had free rein of the park and we didn’t see a single cage the whole time we were there. The monkeys and orangutans have their own sky garden. We were take aback by the animals in the fragile forests and the fact you could walk amongst them. The 2 shows were really fun and entertaining. If you have any doubts about this place I would leave them at home and try for yourself."
+        },
+        {
+          "title": "Most beautiful zoo of the world",
+          "text": "What a beautiful zoo with plenty of space and activities for the animals. We were particularly impressed by the presentation of the animals and the opulent tropical plants and flowers."
+        }
+      ],
+      "description": "Set in a rainforest environment, Singapore Zoo is home to over 2,800 animals from over 300 species of mammals, birds and reptiles. The park also boasts the world's first free-ranging orang utan habitat in a zoo. Delight in an exciting outdoor feast at Jungle Breakfast with Wildlife, an internationally acclaimed, award-winning programme that offers exhilarating experience with orangutans. The fun is endless with interesting animal presentations, photography with animals and more!",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d324542-Reviews-Singapore_Zoo-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "80 Mandai Lake Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "729826",
+        "address_string": "80 Mandai Lake Road, Singapore 729826 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.404348",
+      "longitude": "103.79302",
+      "timezone": "Asia/Singapore",
+      "email": "enquiry@wrs.com.sg",
+      "phone": "+65 6269 3411",
+      "website": "http://www.wrs.com.sg/en/singapore-zoo.html?cmp=www|mp|awa|trt|visit_website|ta||listing|&utm_campaign=trt&utm_medium=visit_website&utm_source=ta&",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d324542-Singapore_Zoo-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#8 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "8"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "22637",
+      "review_rating_count": {
+        "1": "198",
+        "2": "328",
+        "3": "1513",
+        "4": "6145",
+        "5": "14453"
+      },
+      "photo_count": "18362",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d324542-m66827-Reviews-Singapore_Zoo-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0830"
+            },
+            "close": {
+              "day": 1,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0830"
+            },
+            "close": {
+              "day": 2,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0830"
+            },
+            "close": {
+              "day": 3,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0830"
+            },
+            "close": {
+              "day": 4,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0830"
+            },
+            "close": {
+              "day": 5,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0830"
+            },
+            "close": {
+              "day": 6,
+              "time": "1800"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0830"
+            },
+            "close": {
+              "day": 7,
+              "time": "1800"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 08:30 - 18:00",
+          "Tuesday: 08:30 - 18:00",
+          "Wednesday: 08:30 - 18:00",
+          "Thursday: 08:30 - 18:00",
+          "Friday: 08:30 - 18:00",
+          "Saturday: 08:30 - 18:00",
+          "Sunday: 08:30 - 18:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "outdoor_activities",
+          "localized_name": "Outdoor Activities"
+        },
+        {
+          "name": "zoos_aquariums",
+          "localized_name": "Zoos & Aquariums"
+        },
+        {
+          "name": "activities",
+          "localized_name": "Activities"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Zoos & Aquariums",
+          "localized_name": "Zoos & Aquariums",
+          "categories": [
+            {
+              "name": "Zoos",
+              "localized_name": "Zoos"
+            }
+          ]
+        },
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Zoos",
+              "localized_name": "Zoos"
+            }
+          ]
+        },
+        {
+          "name": "Outdoor Activities",
+          "localized_name": "Outdoor Activities",
+          "categories": [
+            {
+              "name": "Zoos",
+              "localized_name": "Zoos"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622334",
+          "name": "Central Water Catchment"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "492"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "5956"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "1183"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "8957"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "2422"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "80 Mandai Lake Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "729826",
+        "address_string": "80 Mandai Lake Road, Singapore 729826 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "River Safari Singapore": [
+    {
+      "location_id": "324761",
+      "name": "Night Safari",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-p/16/65/2b/14/photo0jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1f/d8/be/5a/embark-on-the-tram-safari.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/22/1b/43/b6/ns-retail-shop.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1f/d8/be/6d/meet-our-adorable-free.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1f/d8/be/69/watch-our-leopards-and.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Waste of time and money",
+          "text": "Absolutely rubbish. Added ticket to zoo thinking it would be an ideal evening activity.\n\nThe safari itself was only about 20 minutes with hardly any stops for photos. Not many animals either. Stayed in park less than an hour so complete waste of money. Thinking about contacting for a refund but suspect there will be a stock excuse and no money returned."
+        },
+        {
+          "title": "Best way to see the animals at night",
+          "text": "While visiting the Singapore Zoo, be sure to go on the Night Safari.  It is a 20 minute tour and you will be able to see many interesting animals.  Be sure to get in line before the first tour at 7:15 pm.  The tour is very crowded."
+        },
+        {
+          "title": "Must see",
+          "text": "Kids had fun seeing the animals \n\nThe zoo does not smell bad \n\nInstead of recorded guided tour, why not have a guide to personally explain the animals"
+        },
+        {
+          "title": "One of the coolest zoo!",
+          "text": "Loved this place! We got to see some really cool animals. The tram was awesome, you got to see majority of the animals on it if you don’t want to do the walking trail. \n\nSince it’s a night safari, please do expect low lightings as it is to accommodate the animals. \n\nWe really enjoyed this!"
+        },
+        {
+          "title": "Save your money",
+          "text": "Save your your money! Really not worth it.\nPaid £80 for 2 of us and we hardly saw any animals, all in quite small enclosures (though may only be there at night). Really thought there would be more to see to be honest so not for us."
+        }
+      ],
+      "description": "As dusk falls, get ready as over 1,000 nocturnal animals start their nightly rituals. Come up close to them as they frolic, graze and hunt. With an exciting tram ride that takes you through 7 geographical regions and more, embark on a fascinating journey through the world's very first wildlife night park.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d324761-Reviews-Night_Safari-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "80 Mandai Lake Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "729826",
+        "address_string": "80 Mandai Lake Road, Singapore 729826 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.402199",
+      "longitude": "103.788055",
+      "timezone": "Asia/Singapore",
+      "email": "enquiry@wrs.com.sg",
+      "phone": "+65 6269 3411",
+      "website": "http://www.wrs.com.sg/en/night-safari.html?cmp=www|mp|awa|trt|visit_website|ta||listing|&utm_campaign=trt&utm_medium=visit_website&utm_source=ta&",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d324761-Night_Safari-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#127 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "127"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "12370",
+      "review_rating_count": {
+        "1": "751",
+        "2": "1002",
+        "3": "2271",
+        "4": "3683",
+        "5": "4663"
+      },
+      "photo_count": "4651",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d324761-m66827-Reviews-Night_Safari-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1915"
+            },
+            "close": {
+              "day": 1,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1915"
+            },
+            "close": {
+              "day": 2,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1915"
+            },
+            "close": {
+              "day": 3,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1915"
+            },
+            "close": {
+              "day": 4,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1915"
+            },
+            "close": {
+              "day": 5,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1915"
+            },
+            "close": {
+              "day": 6,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1915"
+            },
+            "close": {
+              "day": 7,
+              "time": "0000"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 19:15 - 00:00",
+          "Tuesday: 19:15 - 00:00",
+          "Wednesday: 19:15 - 00:00",
+          "Thursday: 19:15 - 00:00",
+          "Friday: 19:15 - 00:00",
+          "Saturday: 19:15 - 00:00",
+          "Sunday: 19:15 - 00:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "outdoor_activities",
+          "localized_name": "Outdoor Activities"
+        },
+        {
+          "name": "zoos_aquariums",
+          "localized_name": "Zoos & Aquariums"
+        },
+        {
+          "name": "activities",
+          "localized_name": "Activities"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Zoos & Aquariums",
+          "localized_name": "Zoos & Aquariums",
+          "categories": [
+            {
+              "name": "Zoos",
+              "localized_name": "Zoos"
+            }
+          ]
+        },
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Nature & Wildlife Areas",
+              "localized_name": "Nature & Wildlife Areas"
+            },
+            {
+              "name": "Zoos",
+              "localized_name": "Zoos"
+            }
+          ]
+        },
+        {
+          "name": "Outdoor Activities",
+          "localized_name": "Outdoor Activities",
+          "categories": [
+            {
+              "name": "Zoos",
+              "localized_name": "Zoos"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622334",
+          "name": "Central Water Catchment"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "276"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "3375"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "550"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "4450"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "1631"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "80 Mandai Lake Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "729826",
+        "address_string": "80 Mandai Lake Road, Singapore 729826 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Cable Car Singapore & Mount Faber": [
+    {
+      "location_id": "315470",
+      "name": "Singapore Cable Car",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/11/1e/0a/fly-on-our-thematic-superman.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/11/1e/bd/singapore-cable-car.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/03/a4/4d/d1/singapore-cable-car.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/11/1e/0b/a-must-visit-stop-over.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/00/18/8b/41/cable-cars.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Not worth the money. ",
+          "text": "We took the cable car as a family of 3 and the cost seriously outweighs the highlights.  Mount Faber Peak is just cafes and a gift shop, and the 10 minute walk to Mount Faber Peal Park leads to quite disappointing views.  Don't waste your money."
+        },
+        {
+          "title": "No powerchair access",
+          "text": "They will not let any power or electric wheelchair on at all. Not even if you transfer. Very disappointing . Manual wheelchair users and prams are ok but powerchairs have to go via tram"
+        },
+        {
+          "title": "It's pretty cool",
+          "text": "I rode the cable car just for fun up to Mount Faber, over to Sentosa, then back to the mainland. I didn't see much of anything on Sentosa that I really needed to see, but it was nice riding the cable cars. We also did the upgrade to a SkyOrb and was kind of cool.  None of them were air conditioned, so it was hot."
+        },
+        {
+          "title": "Cable car experience",
+          "text": "Nice cable car trip, but expensive for what it is. You can only ride once, not all day, as we were told.\nHad some lovely views of Sentosa, the beaches and the port"
+        },
+        {
+          "title": "Great way to spend some time without spending a lot of money",
+          "text": "This was a surprisingly interesting attraction. This is my third trip to Singapore but my first time here and I really enjoyed this. \n\nIt was a lovely way to get an overview of lots of things and attractions and sights without needing to commit to any extra expenses.\n\nA weekday morning meant it was very quiet. I imagine it can get very busy other times."
+        }
+      ],
+      "description": "The breath-taking connection between Faber Peak Singapore and Sentosa Island Established since 1974, Singapore Cable Car is the nation's first and only cableway that links Faber Peak on mainland Singapore to the island resort of Sentosa, before flying you to the Merlion or the sandy beach at Siloso. Today, the cable car rides are enjoyed across a Cable Car Sky Network of more than 100 cabins spanning almost 5 kilometres on the Mount Faber Line and the Sentosa Line. A 'joyride' across the Cable Car Sky Network offers a 360-degree aerial and visual treat of the entire Sentosa-HarbourFront skyline and the resort island. The scenery transforms as the cabins soar above the forest, through a skyscraper, over the harbour and travel across the jungle, sand and sea. Our passionate service ambassadors are on hand to create happy moments for all cable car joyriders. Singapore Cable Car Opening Hours: From 8.45am to 10pm (Last boarding: 9.30pm)",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d315470-Reviews-Singapore_Cable_Car-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "109 Mount Faber Road",
+        "street2": "Mount Faber Peak",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "099203",
+        "address_string": "109 Mount Faber Road Mount Faber Peak, Singapore 099203 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.27112",
+      "longitude": "103.8197",
+      "timezone": "Asia/Singapore",
+      "email": "guestrelations@mflg.com.sg",
+      "phone": "+65 6361 0088",
+      "website": "https://www.mountfaberleisure.com/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d315470-Singapore_Cable_Car-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#61 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "61"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "4280",
+      "review_rating_count": {
+        "1": "61",
+        "2": "93",
+        "3": "459",
+        "4": "1481",
+        "5": "2186"
+      },
+      "photo_count": "2643",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d315470-m66827-Reviews-Singapore_Cable_Car-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "0845"
+            },
+            "close": {
+              "day": 1,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "0845"
+            },
+            "close": {
+              "day": 2,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "0845"
+            },
+            "close": {
+              "day": 3,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "0845"
+            },
+            "close": {
+              "day": 4,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "0845"
+            },
+            "close": {
+              "day": 5,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "0845"
+            },
+            "close": {
+              "day": 6,
+              "time": "2200"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "0845"
+            },
+            "close": {
+              "day": 7,
+              "time": "2200"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 08:45 - 22:00",
+          "Tuesday: 08:45 - 22:00",
+          "Wednesday: 08:45 - 22:00",
+          "Thursday: 08:45 - 22:00",
+          "Friday: 08:45 - 22:00",
+          "Saturday: 08:45 - 22:00",
+          "Sunday: 08:45 - 22:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "transportation",
+          "localized_name": "Transportation"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Scenic Walking Areas",
+              "localized_name": "Scenic Walking Areas"
+            },
+            {
+              "name": "Lookouts",
+              "localized_name": "Lookouts"
+            }
+          ]
+        },
+        {
+          "name": "Transportation",
+          "localized_name": "Transportation",
+          "categories": [
+            {
+              "name": "Tramways",
+              "localized_name": "Tramways"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622674",
+          "name": "Mount Faber Park"
+        },
+        {
+          "location_id": "15622331",
+          "name": "Bukit Merah"
+        },
+        {
+          "location_id": "15622611",
+          "name": "Maritime Square"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "142"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "1364"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "257"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "1265"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "547"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "109 Mount Faber Road",
+        "street2": "Mount Faber Peak",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "099203",
+        "address_string": "109 Mount Faber Road Mount Faber Peak, Singapore 099203 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Night Safari, Singapore": [
+    {
+      "location_id": "324761",
+      "name": "Night Safari",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-p/16/65/2b/14/photo0jpg.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1f/d8/be/5a/embark-on-the-tram-safari.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/22/1b/43/b6/ns-retail-shop.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1f/d8/be/6d/meet-our-adorable-free.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/1f/d8/be/69/watch-our-leopards-and.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Waste of time and money",
+          "text": "Absolutely rubbish. Added ticket to zoo thinking it would be an ideal evening activity.\n\nThe safari itself was only about 20 minutes with hardly any stops for photos. Not many animals either. Stayed in park less than an hour so complete waste of money. Thinking about contacting for a refund but suspect there will be a stock excuse and no money returned."
+        },
+        {
+          "title": "Best way to see the animals at night",
+          "text": "While visiting the Singapore Zoo, be sure to go on the Night Safari.  It is a 20 minute tour and you will be able to see many interesting animals.  Be sure to get in line before the first tour at 7:15 pm.  The tour is very crowded."
+        },
+        {
+          "title": "Must see",
+          "text": "Kids had fun seeing the animals \n\nThe zoo does not smell bad \n\nInstead of recorded guided tour, why not have a guide to personally explain the animals"
+        },
+        {
+          "title": "One of the coolest zoo!",
+          "text": "Loved this place! We got to see some really cool animals. The tram was awesome, you got to see majority of the animals on it if you don’t want to do the walking trail. \n\nSince it’s a night safari, please do expect low lightings as it is to accommodate the animals. \n\nWe really enjoyed this!"
+        },
+        {
+          "title": "Save your money",
+          "text": "Save your your money! Really not worth it.\nPaid £80 for 2 of us and we hardly saw any animals, all in quite small enclosures (though may only be there at night). Really thought there would be more to see to be honest so not for us."
+        }
+      ],
+      "description": "As dusk falls, get ready as over 1,000 nocturnal animals start their nightly rituals. Come up close to them as they frolic, graze and hunt. With an exciting tram ride that takes you through 7 geographical regions and more, embark on a fascinating journey through the world's very first wildlife night park.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d324761-Reviews-Night_Safari-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "80 Mandai Lake Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "729826",
+        "address_string": "80 Mandai Lake Road, Singapore 729826 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.402199",
+      "longitude": "103.788055",
+      "timezone": "Asia/Singapore",
+      "email": "enquiry@wrs.com.sg",
+      "phone": "+65 6269 3411",
+      "website": "http://www.wrs.com.sg/en/night-safari.html?cmp=www|mp|awa|trt|visit_website|ta||listing|&utm_campaign=trt&utm_medium=visit_website&utm_source=ta&",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d324761-Night_Safari-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#127 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "127"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "12370",
+      "review_rating_count": {
+        "1": "751",
+        "2": "1002",
+        "3": "2271",
+        "4": "3683",
+        "5": "4663"
+      },
+      "photo_count": "4651",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d324761-m66827-Reviews-Night_Safari-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1915"
+            },
+            "close": {
+              "day": 1,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1915"
+            },
+            "close": {
+              "day": 2,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1915"
+            },
+            "close": {
+              "day": 3,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1915"
+            },
+            "close": {
+              "day": 4,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1915"
+            },
+            "close": {
+              "day": 5,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1915"
+            },
+            "close": {
+              "day": 6,
+              "time": "0000"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1915"
+            },
+            "close": {
+              "day": 7,
+              "time": "0000"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 19:15 - 00:00",
+          "Tuesday: 19:15 - 00:00",
+          "Wednesday: 19:15 - 00:00",
+          "Thursday: 19:15 - 00:00",
+          "Friday: 19:15 - 00:00",
+          "Saturday: 19:15 - 00:00",
+          "Sunday: 19:15 - 00:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "outdoor_activities",
+          "localized_name": "Outdoor Activities"
+        },
+        {
+          "name": "zoos_aquariums",
+          "localized_name": "Zoos & Aquariums"
+        },
+        {
+          "name": "activities",
+          "localized_name": "Activities"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Zoos & Aquariums",
+          "localized_name": "Zoos & Aquariums",
+          "categories": [
+            {
+              "name": "Zoos",
+              "localized_name": "Zoos"
+            }
+          ]
+        },
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Zoos",
+              "localized_name": "Zoos"
+            },
+            {
+              "name": "Nature & Wildlife Areas",
+              "localized_name": "Nature & Wildlife Areas"
+            }
+          ]
+        },
+        {
+          "name": "Outdoor Activities",
+          "localized_name": "Outdoor Activities",
+          "categories": [
+            {
+              "name": "Zoos",
+              "localized_name": "Zoos"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622334",
+          "name": "Central Water Catchment"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "276"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "3375"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "550"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "4450"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "1631"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "80 Mandai Lake Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "729826",
+        "address_string": "80 Mandai Lake Road, Singapore 729826 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Pulau Ubin & Singapore Islands": [
+    {
+      "location_id": "16881900",
+      "name": "Pulau Ubin Nature and Kampong Walk",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/2a/f6/dd/b4/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/17/27/ff/c0/pulau-ubin-nature-and.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/cb/0b/e0/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/cb/0b/df/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2e/cb/0b/de/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Fun spot to bike and hike",
+          "text": "I didn't know about this place until a friend recommended it during my trip. I was staying near Chinatown so it was a bit of a trek to get there. You take a small boat to Pulau Ubin from a terminal, and you need cash to pay the captain directly, but the view is amazing and pretty smooth. After you get off the boat, you will see bike rentals which I highly recommend. It's also worth taking a look at the map so you don't get lost and you know which trails you want to be on. The bikes are your standard rental ones, mine did fine outside of some uneven uphills on the trails. Look at for monkeys-I was surprised by some that crossed a bit ahead of me so I changed directions. The views are great & there's a lot to see. Bring bug spray."
+        },
+        {
+          "title": "Step Back into the Past",
+          "text": "A step back into the past.  Visited in January with family (Singaporean wife+teenage kids) and local friend.  Impressions of the island was a secluded bush forest environment with abundant wildlife eg. Monkeys, snakes, lizards & very few humans.  After catching the local ferry ie. 12 person bumboat (note that they wait to fill all seats before departing otherwise you may have to negotiate a deal if the boats isn't full).  Once you land & absorb the tranquility of being in a Kampong (village), its off to hire a bicycle of which there were 3 shops opened & they all had 2 types - standard and newer (identified as it has bubble wrap around the stem) starting at $S8-$S10/day. Tip - dont assume that the 'newer' bike is better as one of the bikes suddenly disengaged the handle bars from the wheel & became un-steerable.  We stuck mostly to the roads which were more or less level but did stop to hike to the top for the amazing views.  Afterwards, lunch was in the local village where despite the shabby appearance the food was great with Char Kway Teow a standout.  Beware the 'toilet' which turned out to be a hole in the concrete floor (straight into the drain and into the waterway) with a hose to flush. \nTo conclude, a great experience & opportunity to see another side of Singapore away from the concrete jungle.  Take lotsa water as it is hot and only 1  place along the route to replenish."
+        },
+        {
+          "title": "Hard to believe this is also Singapore",
+          "text": "We've been to Singapore before and wanted something different from the usual shops / high rise / hawker centres etc - not that there's anything wrong with that.\nI'd dome a bit of on line research and thought Pulau Ubin would be a great / different day out.\nA taxi ride to Changi Wharf and a short (cash only) boat ride across to the island and we we off.\nNear the jetty there's several bike rental places and a few local eateries. You get hassled a bit for bike rental and we ended up paying $8 per bike. Some have new bikes, some not. We just checked the tyres and brakes before we paid. They were bth OK, older bikes.\nThere's plenty of trails that cover the island and they're all well signposted and there's regular shelters and island maps.\nWe went one way as far as the German Girl Shrine - a great, easy ride and along the way there's several other riders, walkers, locals fishing, monkeys, butterflies and even an Otter.\nWe came back to the jetty area and grabbed some lunch which was good and cheap.\nWe then headed off to the Wetlands - another great ride - some pavement, some dirt, some inclines, but nothing too hard for fit people. Heaps of Monkeys, Wild Boars and other wildlife.\nAt the entrance to the Wetlands you have to park your bike (in a bike parking lot) and walk the rest of the way - don't leave anything with your bike, the local Monkeys will take whatever you leave.\nThe walk is pretty flat and there's a boardwalk that's been built that's really good. We also climbed up a lookout tower and got some great views of the canopy and Malaysia across the water.\nBack to get the bikes and there's a thunderstorm on the way - we decide to ride back to the wharf and end up getting caught in a massive tropical rain / thunder / lightning storm. We end up soaked and in a shelter waiting it out for 1/2 an hour or so and we loved every second of it.\nAn amazing day and the island is such a throwback to what life was like - you can't believe you're in Singapore and just a cab ride away from the city.\nOn the way back you have to go through an airport style security screening when you get off the boat.\nMake sure you take - Cash, Camera, Sunscreen, Hat, good walking shoes.\nGreat day out........"
+        },
+        {
+          "title": "Loved the island!",
+          "text": "One of the highlights of my trip to Singapore is visiting Pulao Ubin. The bike ride to explore this place was such a relaxing time for me. Do take a boat ride which is only a few minutes. Then rent a bike from one of the locals. Don’t forget to bring your binoculars to view different birds. Give way to the monkeys and wild pigs. Don’t forget to bring enough water. Admire the different trees and plants along the trail. After the bike ride, order food from one of the small restaurants and just enjoy the view as you relax yourself!"
+        },
+        {
+          "title": "What a blast",
+          "text": "This island is 15 minutes from SG by boat, but once you get there it's another world. It takes you back 40 years to a place where stress doesn't exist."
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g1644875-d16881900-Reviews-Pulau_Ubin_Nature_and_Kampong_Walk-Pulau_Ubin.html?m=66827",
+      "address_obj": {
+        "street1": "Pulau Ubin Street",
+        "city": "Pulau Ubin",
+        "state": "Pulau Ubin",
+        "country": "Singapore",
+        "address_string": "Pulau Ubin Street, Pulau Ubin Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "Island",
+          "name": "Pulau Ubin",
+          "location_id": "1644875"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.40619",
+      "longitude": "103.96705",
+      "timezone": "Asia/Singapore",
+      "write_review": "https://www.tripadvisor.com/UserReview-g1644875-d16881900-Pulau_Ubin_Nature_and_Kampong_Walk-Pulau_Ubin.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "1644875",
+        "ranking_string": "#2 of 7 things to do in Pulau Ubin",
+        "geo_location_name": "Pulau Ubin",
+        "ranking_out_of": "7",
+        "ranking": "2"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "39",
+      "review_rating_count": {
+        "1": "0",
+        "2": "0",
+        "3": "2",
+        "4": "16",
+        "5": "21"
+      },
+      "photo_count": "137",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g1644875-d16881900-m66827-Reviews-Pulau_Ubin_Nature_and_Kampong_Walk-Pulau_Ubin.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Scenic Walking Areas",
+              "localized_name": "Scenic Walking Areas"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "0"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "5"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "3"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "5"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "8"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "Pulau Ubin Street",
+        "city": "Pulau Ubin",
+        "state": "Pulau Ubin",
+        "country": "Singapore",
+        "address_string": "Pulau Ubin Street, Pulau Ubin Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Little India Singapore: History & Culture": [
+    {
+      "location_id": "324541",
+      "name": "Little India",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0f/a9/7c/62/little-india.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/91/06/59/christmas-decorations.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/da/48/1a/little-india.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/f5/a5/09/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/01/33/6a/36/little-india.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "India 101",
+          "text": "Little India  is a must see and experience when visiting Singapore. This is a charming area, low rise traditional buildings, a reflection of Singapore in the yesteryears. Great food. Plenty of shopping."
+        },
+        {
+          "title": "One of the most authentic Little India I have visited",
+          "text": "This little India is authentic, from the shops to people and food. Great place to buy spices, Indian jewelry, fresh fruits and more. This is not the cleanest place to be in Singapore, but a fun spot to visit.\nDo recommend."
+        },
+        {
+          "title": "Fabulous walking round",
+          "text": "Fantastic walking round little india.  Done this many times.  Has changed a little in terms of choice of shops but you must fi d the silk scarf shop just right off the main   entrance. I've been buying here over 20 years still got original washing and it's as good as new.  Great staff"
+        },
+        {
+          "title": "Not worth the visit, especially if your female ",
+          "text": "We spent 10 minutes there, a look down the street made my wife's hand shake, huge quantities of loitering men, almost no women in sight, side walks jammed full, with some glaring at us, completely unexpected area of Singapore, not worth visiting this area, so glad we didn't book a Hotel room there"
+        },
+        {
+          "title": "Not much to see",
+          "text": "Chaotic but without atmosphere, it leaves much to be desired. Of all the places in Singapore this is by far the one that is not clean as the rest of the city. If you have visited India and know the \"original\", this place is nothing but an area you might want to take a walk though."
+        }
+      ],
+      "description": "An experience for all five senses. Start at the Tekka Centre, a traditional wet market and food court where fresh meat, seafood, vegetables, fruits and dry goods are sold. Cruise down Serangoon Road to find more groceries, restaurants, teahouses, tailors and Mustafa Centre, a massive department store selling anything and everything. Visit during Deepavali, the Hindu festival of light, held in October or November.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d324541-Reviews-Little_India-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Serangoon Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "",
+        "address_string": "Serangoon Road, Singapore Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.30571",
+      "longitude": "103.85151",
+      "timezone": "Asia/Singapore",
+      "phone": "977854985",
+      "website": "http://littleindia.com.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d324541-Little_India-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#97 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "97"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "4150",
+      "review_rating_count": {
+        "1": "153",
+        "2": "264",
+        "3": "959",
+        "4": "1744",
+        "5": "1030"
+      },
+      "photo_count": "4083",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d324541-m66827-Reviews-Little_India-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 2,
+              "time": "1030"
+            },
+            "close": {
+              "day": 2,
+              "time": "1230"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1030"
+            },
+            "close": {
+              "day": 4,
+              "time": "1230"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1030"
+            },
+            "close": {
+              "day": 6,
+              "time": "1230"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: Closed",
+          "Tuesday: 10:30 - 12:30",
+          "Wednesday: Closed",
+          "Thursday: 10:30 - 12:30",
+          "Friday: Closed",
+          "Saturday: 10:30 - 12:30",
+          "Sunday: Closed"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "other",
+          "localized_name": "Other"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Neighborhoods",
+              "localized_name": "Neighborhoods"
+            }
+          ]
+        },
+        {
+          "name": "Other",
+          "localized_name": "Other",
+          "categories": [
+            {
+              "name": "Neighborhoods",
+              "localized_name": "Neighborhoods"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291621",
+          "name": "Little India"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "109"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "1194"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "483"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "691"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "626"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "Serangoon Road",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "",
+        "address_string": "Serangoon Road, Singapore Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "Orchard Road, Singapore: Asia's Most Famous Shopping Street": [
+    {
+      "location_id": "317454",
+      "name": "Orchard Road",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0a/85/2e/7c/at-night.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/19/cd/70/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/19/cd/6e/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/2f/19/cd/6d/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/08/b7/cd/fd/retail-and-entertainment.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Just the main shopping street",
+          "text": "Just the main shopping street in Singapore which features an extensive network of underpasses that connect many of the malls providing even shelter from the blistering equatorial heat."
+        },
+        {
+          "title": "Sensational luxury shopping",
+          "text": "It’s sensational if you want to co some serious luxury shopping! And the customer service at the stores was excellent. If you are a serious shopper you could spend hours here. However if that is not your jam you could check it out and leave within 30 minutes. There are some great little coffee and tea shops though!"
+        },
+        {
+          "title": "Shopping street",
+          "text": "Best place in Singapore for luxury shopping , running errands (going to the bank, supermarket etc), some restaurants/cafes, people watching. Top malls here are Ion, Ngee Ann and Paragon"
+        },
+        {
+          "title": "Orchard Road",
+          "text": "If you like the vibe of big shopping centres then you'll love Orchard Road. Be prepared to max your credit cards as generally it's very expensive. \n\nThere are better things to see, and do with your time in Singapore. Avoid, you can shop at home."
+        },
+        {
+          "title": "oh my orchard!",
+          "text": "been here several times at daytime whenever i get to visit singapore during business trips. this time around, orchard road wowed me with its lavish display of colors and Christmas decors.\n\nthe malls along this road had spent quite a budget to illuminate their facade. i would say it's very impressive. just by walking, one gets to enjoy the sights and sound of the city.\n\nnever come here penniless. part of being in this lion city is to spend for bargain finds especially during sale season."
+        }
+      ],
+      "description": "Spanning almost 2.2 km, Orchard Road is a swanky, tree-lined one-way boulevard flanked by distinctive shopping malls and hotels. The shopping belt comprises nearly 800,000 sq m of shops and restaurants and promises to please any taste or budget with its iconic malls which boast the full works - from opulent brands to high street fashion, and from exclusive restaurants to fast food joints. It is a great street to shop, dine, stay, play, work, and live.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d317454-Reviews-Orchard_Road-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "",
+        "address_string": "Singapore Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.30143",
+      "longitude": "103.83842",
+      "timezone": "Asia/Singapore",
+      "email": "info@orchardroad.org",
+      "phone": "+65 6733 1700",
+      "website": "http://www.orchardroad.org/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d317454-Orchard_Road-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#13 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "13"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "13595",
+      "review_rating_count": {
+        "1": "119",
+        "2": "331",
+        "3": "2266",
+        "4": "5218",
+        "5": "5661"
+      },
+      "photo_count": "5945",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d317454-m66827-Reviews-Orchard_Road-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Points of Interest & Landmarks",
+              "localized_name": "Points of Interest & Landmarks"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622383",
+          "name": "Somerset"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "7291602",
+          "name": "Orchard Road"
+        },
+        {
+          "location_id": "15622376",
+          "name": "Orchard"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "745"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "4073"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "1331"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "2737"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "1836"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "",
+        "address_string": "Singapore Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "MacRitchie Singapore & Singapore Nature Reserve": [
+    {
+      "location_id": "1527627",
+      "name": "MacRitchie Reservoir",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/19/db/7e/a6/the-main-lake-of-the.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/57/7a/da/bedok-reservoir-park.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/09/57/77/8e/bedok-reservoir-park.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/02/2b/5f/bd/les-fameux-singes.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/14/43/e0/19/itineraire-avec-arret.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Boardwalk + View",
+          "text": "Very scenic and peaceful! I walked along the reservoir via the Boardwalk before continuing to one of the longer trails. The boardwalk is not very wide so it can be annoying to squeeze past people especially groups. Bring bugspray and sunscreen! There are some benches where you can rest along the way, and there are some plaques with information about the wildlife on the sides of the boardwalk."
+        },
+        {
+          "title": "Nature made by man  on its best",
+          "text": "Love the green trails.the sites. \nNice way to have morning walks.walking on good trails( you just need to choose one from many) .you can seat or have picnic .just enjoy grate place"
+        },
+        {
+          "title": "Forest in the Metropolis",
+          "text": "It’s really remarkable that large wooded areas like this exist in the middle of Singapore’s concrete jungle. We walked anti-clockwise from the visitor centre, across the zigzag bridge and then along the lakeside boardwalk until we reached the golf course, then doubled back through the forest trail. I estimate we walked about 5 miles over a near 2 hour period. We saw several smallish lizards, Kingfishers, turtles, large fish and a very large monitor, that scuttled underneath the boardwalk as we walked over it. \nWe visited just after rains - the mist rising off the water and through the trees was magical. It cost about S$15 to travel by Grab from the city centre."
+        },
+        {
+          "title": "Macaques galore",
+          "text": "We came for the wildlife and before even beginning the trail had already seen a cloudy monitor, terrapin, and troup of macaques complete with baby, many of whom playing on the exercise equipment. Really lovely day out."
+        },
+        {
+          "title": "Lovely place to visit in Singapore",
+          "text": "This place offers nature away from the city and lovely place to spend time with friends and family. Weekend are usually busy"
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d1527627-Reviews-MacRitchie_Reservoir-Singapore.html?m=66827",
+      "address_obj": {
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "",
+        "address_string": "Singapore Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.344852",
+      "longitude": "103.8254",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 1800 471 7300",
+      "website": "https://www.nparks.gov.sg/nparksbuzz/july-issue-2022/main-feature/hello-macritchie",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d1527627-MacRitchie_Reservoir-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#25 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "25"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "871",
+      "review_rating_count": {
+        "1": "1",
+        "2": "2",
+        "3": "57",
+        "4": "304",
+        "5": "508"
+      },
+      "photo_count": "995",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d1527627-m66827-Reviews-MacRitchie_Reservoir-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "nature_parks",
+          "localized_name": "Nature & Parks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Nature & Parks",
+          "localized_name": "Nature & Parks",
+          "categories": [
+            {
+              "name": "Bodies of Water",
+              "localized_name": "Bodies of Water"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622334",
+          "name": "Central Water Catchment"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "22"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "190"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "130"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "167"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "181"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "",
+        "address_string": "Singapore Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Civic District, Singapore": [
+    {
+      "location_id": "8077179",
+      "name": "National Gallery Singapore",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/11/ec/5b/45/national-gallery-singapore.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0a/38/fb/c9/national-gallery-singapore.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/24/74/e8/36/at-the-gallery.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/24/74/e8/35/padang-atrium.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/24/74/e8/2c/holding-cells.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "That's confusing!",
+          "text": "The banner hung on the outside of the building definitely says 'Free Entry' (see photo), but when we went in, we were asked for $15 each. Didn't stay, as we didn't have enough time to do the charge justice"
+        },
+        {
+          "title": "Majulah",
+          "text": "wonderful place... \nseriously i love singapore , located 1km from merlion park finding remakable art cannot describe 😍"
+        },
+        {
+          "title": "A brilliant space perfect for exploration and discovery",
+          "text": "I was truly in my happy place exploring the many galleries in the National Art Gallery. \n\nThis is truly an incredible building architecturally speaking and it houses an equally impressive modern visual art collection. The finest in South East Asia. There are other galleries here too devoted to the history of art in Singapore & the region, exploring the deep connections between the changes in Singapore and their impact on wider culture and the art scene. I learned so much this morning as this is only my second visit to Singapore and my first with my partner.\n\nThis is where today’s visit was so special. I love art and have done so for many decades, simply put, my partner is not as interested in it as I am. Yet this visit triggered something. What I thought would only be a 1-2 hours at most visit before my partner became restless turned into a half day visit where quite often we wondered off in different directions exploring on our own only for me to discover my partner intently viewing modern works & sculptures and taking lots and lots of photos of the architecture of the amazing building too. \n\nWhen I asked what was different, the response was simply it did not feel like a normal art gallery and the layout and architecture all combined to create an inviting space for exploration & discovery. I hope this is the start of something new for us. Thank you National Gallery Singapore!"
+        },
+        {
+          "title": "A Captivating Journey Through Art and History",
+          "text": "The National Gallery Singapore is a must-visit for art and culture enthusiasts. The beautifully restored buildings house an incredible collection of Southeast Asian and Singaporean art, offering a perfect blend of history and creativity. The exhibits are thoughtfully curated, and the architecture itself is stunning. It’s a place where you can immerse yourself in art while enjoying breathtaking views of the city. Highly recommended!"
+        },
+        {
+          "title": "We've been to art museums all over the world - and this is up there with the best of them",
+          "text": "This sprawling complex offers so much to see that we found several hours had passed almost without us noticing. Staff are incredibly friendly and helpful, there are great places to eat and drink, a nice shop, and amazing architecture. Plus, the art is just so good and so varied, and offers a real insight into Singapore and SE Asia. Highly recommended."
+        }
+      ],
+      "description": "National Gallery Singapore is a leading visual arts institution in Southeast Asia which oversees the world’s largest public collection of modern art in Singapore and the region. Situated in the heart of the Civic District, the National Gallery Singapore has been beautifully restored and transformed from the former Supreme Court and City Hall buildings into an exciting new visual arts venue.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d8077179-Reviews-National_Gallery_Singapore-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 St. Andrew_s Road",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "178957",
+        "address_string": "1 St. Andrew_s Road, Singapore 178957 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.290224",
+      "longitude": "103.85152",
+      "timezone": "Asia/Singapore",
+      "email": "info@nationalgallery.sg",
+      "phone": "+65 6271 7000",
+      "website": "http://www.nationalgallery.sg",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d8077179-National_Gallery_Singapore-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#41 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "41"
+      },
+      "rating": "4.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.5-66827-5.svg",
+      "num_reviews": "1345",
+      "review_rating_count": {
+        "1": "17",
+        "2": "39",
+        "3": "114",
+        "4": "388",
+        "5": "787"
+      },
+      "photo_count": "2527",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d8077179-m66827-Reviews-National_Gallery_Singapore-Singapore.html#photos",
+      "hours": {
+        "periods": [
+          {
+            "open": {
+              "day": 1,
+              "time": "1000"
+            },
+            "close": {
+              "day": 1,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 2,
+              "time": "1000"
+            },
+            "close": {
+              "day": 2,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 3,
+              "time": "1000"
+            },
+            "close": {
+              "day": 3,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 4,
+              "time": "1000"
+            },
+            "close": {
+              "day": 4,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 5,
+              "time": "1000"
+            },
+            "close": {
+              "day": 5,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 6,
+              "time": "1000"
+            },
+            "close": {
+              "day": 6,
+              "time": "1900"
+            }
+          },
+          {
+            "open": {
+              "day": 7,
+              "time": "1000"
+            },
+            "close": {
+              "day": 7,
+              "time": "1900"
+            }
+          }
+        ],
+        "weekday_text": [
+          "Monday: 10:00 - 19:00",
+          "Tuesday: 10:00 - 19:00",
+          "Wednesday: 10:00 - 19:00",
+          "Thursday: 10:00 - 19:00",
+          "Friday: 10:00 - 19:00",
+          "Saturday: 10:00 - 19:00",
+          "Sunday: 10:00 - 19:00"
+        ]
+      },
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "landmarks",
+          "localized_name": "Sights & Landmarks"
+        },
+        {
+          "name": "attractions",
+          "localized_name": "Attractions"
+        },
+        {
+          "name": "museums",
+          "localized_name": "Museums"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Sights & Landmarks",
+          "localized_name": "Sights & Landmarks",
+          "categories": [
+            {
+              "name": "Architectural Buildings",
+              "localized_name": "Architectural Buildings"
+            }
+          ]
+        },
+        {
+          "name": "Museums",
+          "localized_name": "Museums",
+          "categories": [
+            {
+              "name": "Art Museums",
+              "localized_name": "Art Museums"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622412",
+          "name": "City Hall"
+        },
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622675",
+          "name": "Colonial District/Civic District"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "50"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "396"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "252"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "249"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "216"
+        }
+      ],
+      "awards": [
+        {
+          "award_type": "Travelers Choice",
+          "year": "2024",
+          "images": {
+            "tiny": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "small": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png",
+            "large": "https://static.tacdn.com/img2/travelers_choice/widgets/tchotel_2024_L.png"
+          },
+          "categories": [],
+          "display_name": "Travelers Choice"
+        }
+      ],
+      "address": {
+        "street1": "1 St. Andrew_s Road",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "178957",
+        "address_string": "1 St. Andrew_s Road, Singapore 178957 Singapore"
+      },
+      "duration": null
+    }
+  ],
+  "HarbourFront, Singapore": [
+    {
+      "location_id": "7797836",
+      "name": "HarbourFront Centre",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/0f/a4/f5/5c/harbourfront-centre-mall.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/08/3d/6b/7c/harbourfront-centre-singapore.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/08/3d/6c/dd/hfc-is-open-10am-10pm.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/07/d7/79/c8/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/d0/b9/5b/caption.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "Not great",
+          "text": "Quite a depressing mall. Not all shops accept credit cards. It’s almost an afterthought compared to Vivo City next door. Some bargains to be head."
+        },
+        {
+          "title": "YG Mobile Phone Shop",
+          "text": "After purchasing two data SIM cards (10GB and 3GB) from YG Mobile phone Shop before my ferry to Batam, only one card was usable despite our attempts to troubleshoot on both our phones. We resorted to using hotel WiFi and sharing hotspots. Upon returning to Singapore, we visited the shop in hopes of a refund for the unused card, but were informed by the saleswoman who remembered us that refunds were not offered, despite our inability to utilize the data card. Feeling deceived and disappointed, especially after trusting her recommendation to top up for additional GB, we advised the shop to inform customers beforehand about potential issues with the data cards and their no-refund policy. It's regrettable to share this experience, but it's essential to highlight the service quality at this store. There are numerous other mobile service shops in the vicinity worth considering."
+        },
+        {
+          "title": "Huge shopping centre",
+          "text": "HarbourFront Centre adjoins neighbouring Vivo City shopping centre, and is a large shopping centre with a wide variety of shops catering to all tastes. There are more generic and cheaper brands on sale here at HarbourFront.\n\nIt’s worthwhile if you’re visiting VivoCity and heading to Sentosa, unless it’s not really worth going out of your way."
+        },
+        {
+          "title": "Not so interesting",
+          "text": "HarbourFront Centre shopping mall is accessible by MRT via HabourFront MRT station (purple or orange line). The Centre is linked to international cruise centre.\nI was not impressed by the design of the mall and the various shops I have the opportunity to see. I found that there was more coffee shops, restaurant or convenient stores than other shops. A bit disappointed."
+        },
+        {
+          "title": "Ferry mall",
+          "text": "This is the ferry terminal to batam and bintan, and also the tram stop to sentosa. The mall is average, and certainly pales in comparison to vivocity next door. The M1 store is better though"
+        }
+      ],
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d7797836-Reviews-HarbourFront_Centre-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "1 Maritime Square Harbourfront Centre",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "099253",
+        "address_string": "1 Maritime Square Harbourfront Centre, Singapore 099253 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.264194",
+      "longitude": "103.8204",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6377 6311",
+      "website": "http://www.harbourfrontcentre.com.sg/",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d7797836-HarbourFront_Centre-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#186 of 1,250 things to do in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "1250",
+        "ranking": "186"
+      },
+      "rating": "4.0",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/4.0-66827-5.svg",
+      "num_reviews": "137",
+      "review_rating_count": {
+        "1": "3",
+        "2": "4",
+        "3": "36",
+        "4": "69",
+        "5": "25"
+      },
+      "photo_count": "133",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d7797836-m66827-Reviews-HarbourFront_Centre-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "shopping",
+          "localized_name": "Shopping"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Shopping",
+          "localized_name": "Shopping",
+          "categories": [
+            {
+              "name": "Shopping Malls",
+              "localized_name": "Shopping Malls"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622331",
+          "name": "Bukit Merah"
+        },
+        {
+          "location_id": "15622611",
+          "name": "Maritime Square"
+        },
+        {
+          "location_id": "15622673",
+          "name": "Harbourfront"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "7"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "24"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "28"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "38"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "18"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "1 Maritime Square Harbourfront Centre",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "099253",
+        "address_string": "1 Maritime Square Harbourfront Centre, Singapore 099253 Singapore"
+      },
+      "description": null,
+      "duration": null
+    }
+  ],
+  "Bras Basah.Bugis, Singapore Cultural District": [
+    {
+      "location_id": "2338931",
+      "name": "Bras Basah Complex",
+      "photos": [
+        "https://media-cdn.tripadvisor.com/media/photo-s/06/eb/41/37/newer-bookshop-popular.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/0e/c5/68/b1/caption.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-s/27/14/3a/30/sizzling-beef-and-sizzling.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-p/1c/02/83/67/bras-basah-complex.jpg",
+        "https://media-cdn.tripadvisor.com/media/photo-p/1c/02/83/59/bras-basah-complex.jpg"
+      ],
+      "reviews": [
+        {
+          "title": "A local bookstore",
+          "text": "Our specific visit was to the Popular bookstore inside this complex. Plentiful of books and educational materials to look for. We were impressed and happy with the customer service here\n\nWe the stopped by for late lunch in their food court. It was a very small scale food court in comparison to others in the proximity area. Food choices were limited due to only a handful of hawker stalls. Our lunch were white chicken rice, meesiam, Kueh tieu noodle soup and some yong tau foo. The foods were acceptable quality but nothing special to shoutout."
+        },
+        {
+          "title": "Korean food",
+          "text": "We often eat here as we stay at the hotel opposite. We go here with good intensions of looking at all the stalls but once i see the Korean stall open i make a beeline for it. Over the time i have gradually worked my way through most of the menu and i can honestly say i have not had a bad meal."
+        },
+        {
+          "title": "A convenient location to get textbooks.",
+          "text": "In the 1960s and 70s, many of the shophouses along Bras Basah Road, North Bridge Road and Victoria  Street were selling books, stationery and second-hand books as there were many schools in this vicinity such as Raffles Institution, St Joseph Institution, Catholic High and CHIJ etc.  Beside these bookshops, many people also visited the old National Library and MPH nearby in their enthusiastic quest for books.\n\nBy mid 1982, however, the last of the many bookshops at Bras Basah Road had to shut down and they were relocated to the new Bras Basah Complex. The old Bras Basah Road shophouses were later demolished. \n\nWhen the Bras Basah Complex was built, it was designed and designated to be a book centre and the early tenants were book merchants relocated from Bras Basah Road and North Bridge Road.\n\nHowever, now there are other tenants selling of watches, leisure goods. art and craft materials and F&B outlets such as Jack's Place.\n\nI used to frequent the second-hand bookshops here in 2008 in search of Chemistry text books at university level.  These books were often in good conditions and were so much more affordable.  There were also many ten years series on sale here.  I also frequented the stationery shops as well as the printing shop when I needed a poster to be done.  It was also the place to buy textbooks during the December holidays.\n\nStrangely, the National Library is now situated next to it, quite like the good old days."
+        },
+        {
+          "title": "Nostalgia",
+          "text": "Located next to National Library, this used to surrounded by many schools.\nOld style stationery-bookshop theme shopping complex - used to be a haunt for students to hunt for 2nd.hand/pre.owned books, reference & text books & assessment books. It still/also houses shops selling sports equipment, games, art & craft.\nInteresting place to visit.. hv a meal at good old Jack's Place."
+        },
+        {
+          "title": "A glimpse into our culture",
+          "text": "A very old school building with shops mainly focusing on the arts; mainly books and stationery, music equipment, art galleries and craft supplies. The building has \nearned the reputation of being the \"book city of the Singapore\".\nIf you are searching for any old/secondhand books(more Chinese books), it is likely you will be able to find them here. There are also many other well established shops that focus on timepieces, eye wears, printing services and furniture.\n\nWhile the younger generation likes to go to newer mega bookstores like Kinokuniya, it is Bras Basah Complex that still gives us a chance to step into our history, tradition and culture. \n\nHighly recommended!"
+        }
+      ],
+      "description": "Bras Basah Complex is a cultural feast that is full of books, art, music and literature. Just across the road from the famous Raffles Hotel, the complex has a large selection of fiction, children’s books and magazines.",
+      "web_url": "https://www.tripadvisor.com/Attraction_Review-g294265-d2338931-Reviews-Bras_Basah_Complex-Singapore.html?m=66827",
+      "address_obj": {
+        "street1": "Bras Basah Complex, Blk 233 Bain St, #04-11",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "180231",
+        "address_string": "Bras Basah Complex, Blk 233 Bain St, #04-11, Singapore 180231 Singapore"
+      },
+      "ancestors": [
+        {
+          "level": "City",
+          "name": "Singapore",
+          "location_id": "294265"
+        },
+        {
+          "level": "Country",
+          "name": "Singapore",
+          "location_id": "294262"
+        }
+      ],
+      "latitude": "1.296794",
+      "longitude": "103.85406",
+      "timezone": "Asia/Singapore",
+      "phone": "+65 6334 1108",
+      "website": "http://www.yoursingapore.com/content/traveller/en/browse/shopping/shop-by-category/antiques-and-art/bras-basah-complex.html?TAHotelCode=29",
+      "write_review": "https://www.tripadvisor.com/UserReview-g294265-d2338931-Bras_Basah_Complex-Singapore.html?m=66827",
+      "ranking_data": {
+        "geo_location_id": "294265",
+        "ranking_string": "#101 of 856 Shopping in Singapore",
+        "geo_location_name": "Singapore",
+        "ranking_out_of": "856",
+        "ranking": "101"
+      },
+      "rating": "3.5",
+      "rating_image_url": "https://www.tripadvisor.com/img/cdsi/img2/ratings/traveler/3.5-66827-5.svg",
+      "num_reviews": "55",
+      "review_rating_count": {
+        "1": "0",
+        "2": "6",
+        "3": "17",
+        "4": "23",
+        "5": "9"
+      },
+      "photo_count": "60",
+      "see_all_photos": "https://www.tripadvisor.com/Attraction_Review-g294265-d2338931-m66827-Reviews-Bras_Basah_Complex-Singapore.html#photos",
+      "category": {
+        "name": "attraction",
+        "localized_name": "Attraction"
+      },
+      "subcategory": [
+        {
+          "name": "shopping",
+          "localized_name": "Shopping"
+        }
+      ],
+      "groups": [
+        {
+          "name": "Shopping",
+          "localized_name": "Shopping",
+          "categories": [
+            {
+              "name": "Gift & Specialty Shops",
+              "localized_name": "Gift & Specialty Shops"
+            }
+          ]
+        }
+      ],
+      "neighborhood_info": [
+        {
+          "location_id": "15622378",
+          "name": "Central Area/City Area"
+        },
+        {
+          "location_id": "15622411",
+          "name": "Bugis"
+        }
+      ],
+      "trip_types": [
+        {
+          "name": "business",
+          "localized_name": "Business",
+          "value": "1"
+        },
+        {
+          "name": "couples",
+          "localized_name": "Couples",
+          "value": "8"
+        },
+        {
+          "name": "solo",
+          "localized_name": "Solo travel",
+          "value": "25"
+        },
+        {
+          "name": "family",
+          "localized_name": "Family",
+          "value": "6"
+        },
+        {
+          "name": "friends",
+          "localized_name": "Friends getaway",
+          "value": "4"
+        }
+      ],
+      "awards": [],
+      "address": {
+        "street1": "Bras Basah Complex, Blk 233 Bain St, #04-11",
+        "street2": "",
+        "city": "Singapore",
+        "country": "Singapore",
+        "postalcode": "180231",
+        "address_string": "Bras Basah Complex, Blk 233 Bain St, #04-11, Singapore 180231 Singapore"
+      },
+      "duration": null
+    }
+  ]
+}


### PR DESCRIPTION
Previous run of `gov_attractions:merge` rake task requires 300+ API calls to TripAdvisor. Dangerous considering there's a 5000 free API call limit.

Populated a JSON file with the attractions data instead.